### PR TITLE
Added support for inline comments and customising indenting

### DIFF
--- a/py8dis/acme.py
+++ b/py8dis/acme.py
@@ -51,7 +51,7 @@ def disassembly_start():
     return []
 
 def code_start(start_addr, end_addr):
-    return ["    * = %s\n" % hex4(start_addr)]
+    return ["", "%s* = %s" % (utils.make_indent(1), hex4(start_addr)), ""]
 
 def code_end():
     return []
@@ -62,38 +62,34 @@ def pseudopc_start(dest, source, length):
 def pseudopc_end(dest, source, length):
     return ["}", ""]
 
-# TODO: Not just here, I hate the inline "\n" mess with a lot of these functions. I should convert them to return a list of lines which will be joined with "\n" when finally emitted.
 def disassembly_end():
     result = []
     spa = sorted((str(expr), hex(value)) for expr, value in _pending_assertions.items())
     for expr, value in spa:
         result.append("%s (%s) != %s {" % (utils.force_case("!if"), expr, value))
-        result.append('    %s "Assertion failed: %s == %s"' % (utils.force_case("!error"), expr, value))
+        result.append('%s%s "Assertion failed: %s == %s"' % (utils.make_indent(1), utils.force_case("!error"), expr, value))
         result.append("}")
     return result
 
 def force_abs_instruction(instruction, prefix, operand, suffix):
-    return utils.LazyString("    %s+2 %s%s%s", instruction, prefix, operand, suffix)
-
-def abs_suffix():
-    return "+2"
+    return utils.LazyString("%s%s+2 %s%s%s", utils.make_indent(1), instruction, prefix, operand, suffix)
 
 def byte_prefix():
-    return utils.force_case("    !byte ")
+    return utils.force_case("!byte ")
 
 def word_prefix():
-    return utils.force_case("    !word ")
+    return utils.force_case("!word ")
 
 def string_prefix():
-    return utils.force_case("    !text ")
+    return utils.force_case("!text ")
 
-def string_chr(c):
-    if c == ord('\\'):
+def string_chr(i):
+    if i == ord('\\'):
         return '\\\\'
-    if c == ord('"'):
+    if i == ord('"'):
         return '\\"'
-    if utils.isprint(c):
-        return chr(c)
+    if utils.isprint(i):
+        return chr(i)
     return None
 
 def binary_prefix():

--- a/py8dis/beebasm.py
+++ b/py8dis/beebasm.py
@@ -48,7 +48,7 @@ def assert_expr(expr, value):
 def set_cmos(b):
     global _disassembly_start
     if b:
-        _disassembly_start = [utils.force_case("    cpu 1"), ""]
+        _disassembly_start = [utils.make_indent(1) + utils.force_case("cpu 1"), ""]
 
 def disassembly_start():
     return _disassembly_start
@@ -57,7 +57,7 @@ def disassembly_start():
 def code_start(start_addr, end_addr):
     global _code_end_addr
     _code_end_addr = end_addr
-    result = ["", utils.force_case("    org %s" % hex4(start_addr))]
+    result = ["", utils.make_indent(1) + utils.force_case("org %s" % hex4(start_addr))]
     result.append("")
     return result
 
@@ -66,7 +66,7 @@ def code_end():
 
 def pseudopc_start(dest, source, length):
     result = [""]
-    result.append(utils.force_case("    org %s" % hex(dest)))
+    result.append(utils.make_indent(1) + utils.force_case("org %s" % hex(dest)))
     # TODO: We will need some labels in pseudopc_end() but by then it will be too late to
     # create them, so do it now. Is this hacky or OK?
     # TODO: The idea of including move_id here is to force the labels to be emitted "around" the pseudopc-emulation block, which is both more readable and necessary in some cases to avoid assembly problems where a label is not forward declared. It isn't working quite right yet.
@@ -83,16 +83,16 @@ def pseudopc_end(dest, source, length):
     result = []
     # TODO: Use LazyString?
     move_id = movemanager.move_id_for_binary_addr[source]
-    result.append("    %s %s + (%s - %s)" % (utils.force_case("org"), disassembly.get_label(source, source, move_id), disassembly.get_label(dest + length, source, move_id), disassembly.get_label(dest, source, move_id)))
-    result.append("    %s %s, %s, %s" % (utils.force_case("copyblock"), disassembly.get_label(dest, source, move_id), disassembly.get_label(dest + length, source, move_id), disassembly.get_label(source, source, move_id)))
-    result.append("    %s %s, %s" % (utils.force_case("clear"), disassembly.get_label(dest, source, move_id), disassembly.get_label(dest + length, source, move_id)))
+    result.append("%s%s %s + (%s - %s)" % (utils.make_indent(1), utils.force_case("org"), disassembly.get_label(source, source, move_id), disassembly.get_label(dest + length, source, move_id), disassembly.get_label(dest, source, move_id)))
+    result.append("%s%s %s, %s, %s" % (utils.make_indent(1), utils.force_case("copyblock"), disassembly.get_label(dest, source, move_id), disassembly.get_label(dest + length, source, move_id), disassembly.get_label(source, source, move_id)))
+    result.append("%s%s %s, %s" % (utils.make_indent(1), utils.force_case("clear"), disassembly.get_label(dest, source, move_id), disassembly.get_label(dest + length, source, move_id)))
     result.append("")
     return result
 
 def disassembly_end():
     result = []
     spa = sorted((str(expr), hex(value)) for expr, value in _pending_assertions.items())
-    result.extend(utils.force_case("    assert ") + "%s == %s" % (expr, value) for expr, value in spa)
+    result.extend(utils.make_indent(1) + utils.force_case("assert ") + "%s == %s" % (expr, value) for expr, value in spa)
     result.append("")
 
     s = utils.force_case("save")
@@ -107,13 +107,13 @@ def force_abs_instruction(instruction, prefix, operand, suffix):
     return None
 
 def byte_prefix():
-    return utils.force_case("    equb ")
+    return utils.force_case("equb ")
 
 def word_prefix():
-    return utils.force_case("    equw ")
+    return utils.force_case("equw ")
 
 def string_prefix():
-    return utils.force_case("    equs ")
+    return utils.force_case("equs ")
 
 def string_chr(c):
     if utils.isprint(c) and chr(c) not in ('"'):

--- a/py8dis/commands.py
+++ b/py8dis/commands.py
@@ -98,15 +98,17 @@ def optional_label(runtime_addr, name, base_runtime_addr=None):
         base_runtime_addr = utils.RuntimeAddr(base_runtime_addr)
     disassembly.add_optional_label(runtime_addr, name, base_runtime_addr)
 
-def comment(runtime_addr, text):
+def comment(runtime_addr, text, inline=False):
     runtime_addr = utils.RuntimeAddr(runtime_addr)
-    formatted_comment(runtime_addr, newformatter.format_comment(text))
+    if not inline:
+        text = newformatter.format_comment(text)
+    formatted_comment(runtime_addr, text, inline)
 
-def formatted_comment(runtime_addr, text):
+def formatted_comment(runtime_addr, text, inline=False):
     runtime_addr = utils.RuntimeAddr(runtime_addr)
     binary_addr, _ = movemanager.r2b_checked(runtime_addr)
     assert utils.data_loaded_at_binary_addr(binary_addr)
-    disassembly.add_comment(binary_addr, text)
+    disassembly.add_comment(binary_addr, text, inline)
 # TODO: UP TO HERE WITH ADDING RUNTIMEADDR() CALLS
 
 def annotate(runtime_addr, s, priority=None):
@@ -122,7 +124,6 @@ def expr(runtime_addr, s):
     assert utils.data_loaded_at_binary_addr(binary_addr)
     classification.add_expression(binary_addr, s)
 
-# TODO: Add "cols" to word() as well
 def byte(runtime_addr, n=1, cols=None, warn=True):
     runtime_addr = utils.RuntimeAddr(runtime_addr)
     binary_addr, _ = movemanager.r2b_checked(runtime_addr)

--- a/py8dis/config.py
+++ b/py8dis/config.py
@@ -26,7 +26,8 @@ _bytes_as_ascii = True
 _hex_dump = True
 _label_references = True
 
-_inline_comment_column = 60
+_inline_comment_column = 70
+_indent_string = " "*4
 
 _disassemble_instruction = None
 
@@ -80,11 +81,20 @@ def set_inline_comment_column(n):
     global _inline_comment_column
     _inline_comment_column = n
 
+def indent_string():
+    global _indent_string
+    return _indent_string
+
+def set_indent_string(s):
+    global _indent_string
+    _indent_string = s
+
+def disassemble_instruction():
+    assert _disassemble_instruction is not None
+    return _disassemble_instruction
+
 def set_disassemble_instruction(f):
     global _disassemble_instruction
     assert _disassemble_instruction is None
     _disassemble_instruction = f
 
-def disassemble_instruction():
-    assert _disassemble_instruction is not None
-    return _disassemble_instruction

--- a/py8dis/labelmanager.py
+++ b/py8dis/labelmanager.py
@@ -49,14 +49,13 @@ import disassembly # TODO!?
 import movemanager
 import utils
 
-# TODO: I think Name is an implementation detail of Label - users of Label won't see it.
-# TODO: General point - perhaps having this class called Name and thus it being natural to use "name" as a local variable holding an instance of this class and then having to say "name.name" is a bit confusing
-class Name(object):
-    def __init__(self, name):
-        self.name = name
-        self.emitted = False
-
 class Label(object):
+    # TODO: General point - perhaps having this class called Name and thus it being natural to use "name" as a local variable holding an instance of this class and then having to say "name.name" is a bit confusing
+    class Name(object):
+        def __init__(self, name):
+            self.name = name
+            self.emitted = False
+
     def __init__(self, addr):
         self.addr = int(addr) # TODO: cast to int is experimental - if keep this, other cast-y stuff might be redundant
         self.move_id = movemanager.base_move_id
@@ -91,7 +90,7 @@ class Label(object):
         assert movemanager.is_valid_move_id(move_id)
         # TODO: What if the name already exists but with a different move_id? We probably shouldn't allow it to exist with both - we don't want to assume the assembler will accept duplicate definitions of the same label name - but maybe we should be erroring, warning or *changing* the move_id of the existing label. Or just possibly - this might be useful for auto-generated labels, at least - we want to be appending some sort of suffix to allow differently named variants of the label to exist in different move IDs. (Imagine we're tracing some code, and move IDs 0 and 1 both contain "bne &905"; we don't want to generate one l090 label and put it in one move ID and leave the other one implicit.)
         if name not in self.all_names():
-            self.explicit_names[move_id].append(Name(name))
+            self.explicit_names[move_id].append(self.Name(name))
 
     # TODO: Bit experimental, also bit copy-and-paste of add_explicit_name()
     def add_expression(self, s, move_id):

--- a/py8dis/movemanager.py
+++ b/py8dis/movemanager.py
@@ -75,7 +75,7 @@ def is_valid_runtime_addr_for_move_id(runtime_addr, move_id):
 # TODO: Name for this function is perhaps not ideal
 # TODO: This should almost certainly be handled via Move() object returned by move() fn
 # which would allow us to write "with move(blah)" instead of "id = move(blah); with moved(id)"
-# TODOCOMMETEDOUT @contextlib.contextmanager
+# TODOCOMMENTEDOUT @contextlib.contextmanager
 def moved(move_id):
     # TODO: This function is redundant now we have Move() objects which are context managers themselves; it should be done away with eventually, but for now let's keep it as a no-op
     assert isinstance(move_id, Move)

--- a/py8dis/trace.py
+++ b/py8dis/trace.py
@@ -90,7 +90,8 @@ def add_references_comments():
     for addr, addr_refs in references.items():
         count = "%d times" % len(addr_refs) if len(addr_refs) != 1 else "1 time" # TODO: Use utils.plural
         # TODO: Where the comment has to be emitted slightly out of place due to a classification, this becomes a bit confusing - we should probably be smarter, peek the classifications and generate a variant comment in that case at the "can actually be emitted" address - and/or maybe we shouldn't be generating reference comments for non-simple labels? (probably not the only way the first problem can occur though) - or maybe we should be forcibly breaking classifications for these? or maybe we should be attaching the comment inline to the relevant label (but that might be confusing if there are multiple labels for the same address) - for the moment I am always including 'addr' in the comment which helps a bit but isn't ideal
-        disassembly.add_comment(addr, "%s referenced %s by %s" % (config.formatter().hex4(addr), count, ", ".join(sorted(config.formatter().hex4(movemanager.b2r(addr_ref)) for addr_ref in addr_refs))))
+        comment = "%s referenced %s by %s" % (config.formatter().hex4(addr), count, ", ".join(sorted(config.formatter().hex4(movemanager.b2r(addr_ref)) for addr_ref in addr_refs)))
+        disassembly.add_comment(addr, comment, False)
 
 def add_reference_histogram():
     if len(references) == 0:

--- a/py8dis/trace8080.py
+++ b/py8dis/trace8080.py
@@ -28,8 +28,8 @@ class Opcode(object):
     def is_code(self, addr):
         return True
 
-    def as_string_list(self, addr):
-        return [utils.add_hex_dump(self.as_string(addr), addr, self.length())]
+    def as_string_list(self, addr, annotations):
+        return [newformatter.add_inline_comment(addr, self.length(), annotations, self.as_string(addr))]
 
 
 class OpcodeImplied(Opcode):
@@ -45,7 +45,7 @@ class OpcodeImplied(Opcode):
         mnemonic = self.mnemonic
         if (not config.formatter().explicit_a) and mnemonic.endswith(" A"):
             mnemonic = mnemonic[:-2]
-        return "    %s" % utils.force_case(mnemonic)
+        return "%s%s" % (utils.make_indent(1), utils.force_case(mnemonic))
 
 
 class OpcodeConditionalBranch(Opcode):
@@ -59,7 +59,7 @@ class OpcodeConditionalBranch(Opcode):
         return [addr + 3, self._target(addr)]
 
     def as_string(self, addr):
-        return "    %s %s" % (utils.force_case(self.mnemonic), disassembly.get_label(self._target(addr), addr))
+        return "%s%s %s" % (utils.make_indent(1), utils.force_case(self.mnemonic), disassembly.get_label(self._target(addr), addr))
 
 
 opcodes = {

--- a/py8dis/xa.py
+++ b/py8dis/xa.py
@@ -50,7 +50,7 @@ def disassembly_start():
     return []
 
 def code_start(start_addr, end_addr):
-    return ["    * = %s\n" % hex4(start_addr)]
+    return ["%s* = %s" % (utils.make_indent(1), hex4(start_addr)), ""]
 
 def code_end():
     return []
@@ -76,7 +76,7 @@ def disassembly_end():
     spa = sorted((str(expr), hex(value)) for expr, value in _pending_assertions.items())
     for expr, value in spa:
         result.append("%s %s <> %s" % (utils.force_case("#if"), expr, value))
-        result.append("    #echo TODO") # result.append('    %s Assertion failed: %s == %s' % (utils.force_case("#echo"), expr, value))
+        result.append("    #echo TODO") # result.append(utils.make_indent(1) + '%s Assertion failed: %s == %s' % (utils.force_case("#echo"), expr, value))
         result.append(utils.force_case("#endif"))
     return result
 
@@ -84,16 +84,16 @@ def force_abs_instruction(instruction, prefix, operand, suffix):
     # It's tempting to put brackets around "operand" in case it contains an
     # expression, but the "!" prefix operator doesn't seem to like this and
     # probably doesn't need it.
-    return utils.LazyString("    %s %s!%s%s", instruction, prefix, operand, suffix)
+    return utils.LazyString("%s%s %s!%s%s", utils.make_indent(1), instruction, prefix, operand, suffix)
 
 def byte_prefix():
-    return utils.force_case("    .byt ")
+    return utils.force_case(".byt ")
 
 def word_prefix():
-    return utils.force_case("    .word ")
+    return utils.force_case(".word ")
 
 def string_prefix():
-    return utils.force_case("    .asc ")
+    return utils.force_case(".asc ")
 
 def string_chr(c):
     if chr(c) in '^"':


### PR DESCRIPTION
* Added support for inline comments by adding an optional 'inline=False' boolean parameter to the comment() and formatted_comment() commands.

* Also, the default indenting of four spaces can now be configured with a set_indent_string() in the config. e.g. to change to a tab, or a different number of spaces.

* A few minor tweaks to code, e.g. putting functions into utils where appropriate.

* Also... numbers in byte or word data blocks are right justified.