### PR TITLE
Make expressions and more enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ There are functions to help construct expression strings that will work across a
 
 :pencil:make_op1(op, expr)
 
-For unary operators. For example `make_op1('<', 'input_bits')` might return `'<input_bits'` or `'LO(input_bits)'` depending on the assembler.
+For unary operators. For example `make_op1('NOT', 'input_bits')` might return `'!input_bits'` or `'NOT(input_bits)'` depending on the assembler.
 
 :pencil:make_op2(expr1, op, expr2)
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,38 @@ Associate expression `s` with address `addr`. Any reference to `addr` in an inst
 
 Example: `lda $1ee4,x` could be replaced with `lda current_level_data+1,x`
 
+#### Making expression strings
+There are functions to help construct expression strings that will work across all assemblers:
+
+:pencil:make_op1(op, expr)
+
+For unary operators. For example `make_op1('<', 'input_bits')` might return `'<input_bits'` or `'LO(input_bits)'` depending on the assembler.
+
+:pencil:make_op2(expr1, op, expr2)
+
+For binary operators, e.g. `make_op2('address', 'DIV', 8)`
+
+All the usual operators, +, -, *, / and so on can be used. It will accept common alternatives, 'AND' or '&' for example, 'XOR' or 'EOR'. These will be translated appropriately for the current assembler.
+
+There are convenience functions for common uses of the above:
+
+| Function                                  | Description                                                   |
+| :---------------------------------------- | :------------------------------------------------------------ |
+| :pencil:`make_lo(expr)`                   | for the low byte of a number                                  |
+| :pencil:`make_hi(expr)`                   | for the high byte of a number                                 |
+| :pencil:`make_add(expr1, expr2)`          | add                                                           |
+| :pencil:`make_subtract(expr1, expr2)`     | subtract                                                      |
+| :pencil:`make_multiply(expr1, expr2)`     | multiply                                                      |
+| :pencil:`make_divide(expr1, expr2)`       | divide                                                        |
+| :pencil:`make_or(expr1, expr2)`           | bitwise or                                                    |
+| :pencil:`make_and(expr1, expr2)`          | bitwise and                                                   |
+| :pencil:`make_eor(expr1, expr2)`          | bitwise eor (synonym for make_xor)                            |
+| :pencil:`make_xor(expr1, expr2)`          | bitwise xor                                                   |
+| :pencil:`make_modulo(expr1, expr2)`       | remainder after division                                      |
+
+Calls can be strung together: `make_lo(make_add('level_data', 1))` 
+
+
 ### Marking data
 
 #### Bytes and Words
@@ -324,7 +356,11 @@ Define a subroutine. All parameters except the address are optional. These are u
 ; ***************************************************************************************
 ```
 
-The `on_entry` and `on_exit` optional parameters are dictionaries that specify a comment for each register as required. e.g. `on_entry={ 'a': "number to print" }`. The `is_entry_point` parameter adds the address as an entry point for code. The `hook` parameter is a callback to allow for the decoration of the calling code.
+The `on_entry` and `on_exit` optional parameters are dictionaries that specify a comment for each register as required. e.g. `on_entry={ 'a': "number to print" }`. If a parameter description is in brackets, it is not used when decorating calls to this routine. This allows for `{ 'x': '(preserved)' }` style descriptions.
+
+The `is_entry_point` parameter adds the address as an entry point for code. 
+
+The `hook` parameter is a callback to allow for the decoration of the calling code. 
 
 :pencil:`no_automatic_comment(addr)`
 

--- a/examples/chuckie.py
+++ b/examples/chuckie.py
@@ -69,8 +69,8 @@ def get_label(addr):
 def ldxy(addr):
     test_addr = memory[addr+1] + 256 * memory[addr+3]
     lab = get_label(test_addr)
-    expr(addr + 1, "<" + lab)
-    expr(addr + 3, ">" + lab)
+    expr(addr + 1, make_lo(lab))
+    expr(addr + 3, make_hi(lab))
 
 def label_skip(addr):
     global global_skip
@@ -1139,8 +1139,8 @@ expr(0x269e, "DigitsColour")
 expr(0x2ce6, "LogoColour")
 expr(0x2ead, "LiftColour")
 expr(0x2f65, "LivesColour")
-expr(0x2921, "<osword0block")
-expr(0x2923, ">osword0block")
+expr(0x2921, make_lo("osword0block"))
+expr(0x2923, make_hi("osword0block"))
 
 expr(0x091c, "255 - inkey_key_h")
 expr(0x1ab6, "DigitsColour")
@@ -1148,10 +1148,10 @@ expr(0x1b08, sprite_constants)
 expr(0x1bdb, "LadderColour")
 expr(0x1ef4, "MapId_Platform")
 
-expr(0x19e6, "<spritetable")
-expr(0x19ec, ">spritetable")
-expr(0x278c, "<hiscoretab")
-expr(0x2792, ">hiscoretab")
+expr(0x19e6, make_lo("spritetable"))
+expr(0x19ec, make_hi("spritetable"))
+expr(0x278c, make_lo("hiscoretab"))
+expr(0x2792, make_hi("hiscoretab"))
 expr(0x299D, "hiscorenamebuffer")
 expr(0x299F, "hiscorenamebuffer_end - hiscorenamebuffer - 1")
 

--- a/examples/dfs226.py
+++ b/examples/dfs226.py
@@ -33,14 +33,14 @@ expr_label(0xacdb + 0x100, "tube_host_code2+256")
 wordentry(0x500, 12)
 entry(0x406, "tube_entry")
 entry(0x06ad, "tube_evntv_handler")
-expr(0xaef9, "<tube_evntv_handler")
-expr(0xaefe, ">tube_evntv_handler")
+expr(0xaef9, make_lo("tube_evntv_handler"))
+expr(0xaefe, make_hi("tube_evntv_handler"))
 # ENHANCE: We have tube_brkv_handler_fwd to stop beebasm failing (I haven't tried other assemblers) when tube_brkv_handler is a zero-page address but we don't realise before it is first used and the two passes get out of sync. I'm not sure we can handle this automatically, but perhaps we could.
 constant(0x0016, "tube_brkv_handler_fwd")
 expr(0xaf31, "tube_brkv_handler_fwd")
 entry(0x0016, "tube_brkv_handler") # TODO: This is breaking beebasm because it gets emitted "inline" too late for other code to realise on the first pass it is a zero page label (and we can't declare it *also* as a constant, as we then get a redefinition error)
-expr(0xaf03, "<tube_brkv_handler")
-expr(0xaf08, ">tube_brkv_handler")
+expr(0xaf03, make_lo("tube_brkv_handler"))
+expr(0xaf08, make_hi("tube_brkv_handler"))
 # TODO: Possible bug: we should be inlining a label definition l06a7 at binary &ae82; this *is* within a move() region but (perhaps due to the order things happen to be identified in) that label is associated with move ID 0, which means it never gets emitted inline at all and so it is emitted as an explicit value. The two possible areas of problem are a) should we (even if only by heuristic) be assigning it to a different move ID, or allowing it to change move ID/exist in multiple move IDs b) since it will never be emitted inline using the sole move ID 0 which it has, should be we realising that it's probably smart to output it in move 2 which *does* cover this address implicitly?
 # - OK, the reason this is assigned to move ID 0 is that the sole reference to 06a7 is from code in move ID 1 where 6a7 is in move ID 2, so (not unreasonably) we don't heuristically assign move ID 2 but leave it with a default of 0. TODO: Probably too hard for the benefit, but if we could somehow arrange for the two disjoint tube host code move()s to either *be* the same move ID or for their move IDs to be linked by the user, we could potentially then DTRT heuristically.
 # - TODO: don't forget the separate issue of "should we improve label emitting so we can use an implicit label where possible despite move ID"?

--- a/examples/dfs226b.py
+++ b/examples/dfs226b.py
@@ -48,14 +48,14 @@ with move(0x8000, 0x2000, 0x4000):
     entry(0x49b) # XXX: how is this reached?
     entry(0x4ce) # XXX: how is this reached?
     entry(0x06ad, "tube_evntv_handler")
-    expr(0xaef9, "<tube_evntv_handler")
-    expr(0xaefe, ">tube_evntv_handler")
+    expr(0xaef9, make_lo("tube_evntv_handler"))
+    expr(0xaefe, make_hi("tube_evntv_handler"))
     # ENHANCE: We have tube_brkv_handler_fwd to stop beebasm failing (I haven't tried other assemblers) when tube_brkv_handler is a zero-page address but we don't realise before it is first used and the two passes get out of sync. I'm not sure we can handle this automatically, but perhaps we could.
     constant(0x0016, "tube_brkv_handler_fwd")
     expr(0xaf31, "tube_brkv_handler_fwd")
     entry(0x0016, "tube_brkv_handler") # TODO: This is breaking beebasm because it gets emitted "inline" too late for other code to realise on the first pass it is a zero page label (and we can't declare it *also* as a constant, as we then get a redefinition error)
-    expr(0xaf03, "<tube_brkv_handler")
-    expr(0xaf08, ">tube_brkv_handler")
+    expr(0xaf03, make_lo("tube_brkv_handler"))
+    expr(0xaf08, make_hi("tube_brkv_handler"))
     # TODO: Possible bug: we should be inlining a label definition l06a7 at binary &ae82; this *is* within a move() region but (perhaps due to the order things happen to be identified in) that label is associated with move ID 0, which means it never gets emitted inline at all and so it is emitted as an explicit value. The two possible areas of problem are a) should we (even if only by heuristic) be assigning it to a different move ID, or allowing it to change move ID/exist in multiple move IDs b) since it will never be emitted inline using the sole move ID 0 which it has, should be we realising that it's probably smart to output it in move 2 which *does* cover this address implicitly?
     # - OK, the reason this is assigned to move ID 0 is that the sole reference to 06a7 is from code in move ID 1 where 6a7 is in move ID 2, so (not unreasonably) we don't heuristically assign move ID 2 but leave it with a default of 0. TODO: Probably too hard for the benefit, but if we could somehow arrange for the two disjoint tube host code move()s to either *be* the same move ID or for their move IDs to be linked by the user, we could potentially then DTRT heuristically.
     # - TODO: don't forget the separate issue of "should we improve label emitting so we can use an implicit label where possible despite move ID"?

--- a/examples/known_good/acorn_os_calls_acme.asm
+++ b/examples/known_good/acorn_os_calls_acme.asm
@@ -1,4 +1,34 @@
 ; Constants
+baud_rate_1200                                     = 4
+baud_rate_150                                      = 2
+baud_rate_19200                                    = 8
+baud_rate_2400                                     = 5
+baud_rate_300                                      = 3
+baud_rate_4800                                     = 6
+baud_rate_75                                       = 1
+baud_rate_9600                                     = 7
+baud_rate_default_9600                             = 0
+buffer_keyboard                                    = 0
+buffer_printer                                     = 3
+buffer_rs423_input                                 = 1
+buffer_rs423_output                                = 2
+buffer_sound_channel_0                             = 4
+buffer_sound_channel_1                             = 5
+buffer_sound_channel_2                             = 6
+buffer_sound_channel_3                             = 7
+buffer_speech                                      = 8
+event_adc_conversion_complete                      = 3
+event_character_entering_input_buffer              = 2
+event_escape_condition_detected                    = 6
+event_input_buffer_full                            = 1
+event_interval_timer_crossing_zero                 = 5
+event_network_error                                = 8
+event_output_buffer_empty                          = 0
+event_rs423_error                                  = 7
+event_start_of_vertical_sync                       = 4
+event_user                                         = 9
+inkey_key_ctrl                                     = 254
+inkey_key_f0                                       = 223
 inkey_key_shift                                    = 255
 osbyte_acknowledge_escape                          = 126
 osbyte_check_eof                                   = 127
@@ -177,6 +207,10 @@ osfile_write_attributes                            = 4
 osfile_write_catalogue_info                        = 1
 osfile_write_exec_addr                             = 3
 osfile_write_load_addr                             = 2
+osfind_close                                       = 0
+osfind_open_input                                  = 64
+osfind_open_output                                 = 128
+osfind_open_random_access                          = 192
 osgbpb_append_bytes                                = 2
 osgbpb_read_bytes_from_current_position            = 4
 osgbpb_read_bytes_from_position                    = 3
@@ -311,19 +345,19 @@ pydis_start
     lda #osbyte_set_cursor_editing                                    ; 118f: a9 04       ..
     ldx #0                                                            ; 1191: a2 00       ..
     ldy #0                                                            ; 1193: a0 00       ..
-    jsr osbyte                                                        ; 1195: 20 f4 ff     ..            ; Enable cursor editing
+    jsr osbyte                                                        ; 1195: 20 f4 ff     ..            ; Enable cursor editing (X=0)
     lda #osbyte_set_cursor_editing                                    ; 1198: a9 04       ..
     ldx #1                                                            ; 119a: a2 01       ..
     ldy #0                                                            ; 119c: a0 00       ..
-    jsr osbyte                                                        ; 119e: 20 f4 ff     ..            ; Disable cursor editing (edit keys give ASCII 135-139)
+    jsr osbyte                                                        ; 119e: 20 f4 ff     ..            ; Disable cursor editing (edit keys give ASCII 135-139) (X=1)
     lda #osbyte_set_cursor_editing                                    ; 11a1: a9 04       ..
     ldx #2                                                            ; 11a3: a2 02       ..
     ldy #0                                                            ; 11a5: a0 00       ..
-    jsr osbyte                                                        ; 11a7: 20 f4 ff     ..            ; Disable cursor editing (edit keys act as soft keys f11 to f15)
+    jsr osbyte                                                        ; 11a7: 20 f4 ff     ..            ; Disable cursor editing (edit keys act as soft keys f11 to f15) (X=2)
     lda #osbyte_set_cursor_editing                                    ; 11aa: a9 04       ..
     ldx #3                                                            ; 11ac: a2 03       ..
     ldy #0                                                            ; 11ae: a0 00       ..
-    jsr osbyte                                                        ; 11b0: 20 f4 ff     ..            ; Cursor editing keys and COPY simulate a joystick (Master Compact only)
+    jsr osbyte                                                        ; 11b0: 20 f4 ff     ..            ; Cursor editing keys and COPY simulate a joystick (Master Compact only) (X=3)
     lda #osbyte_set_cursor_editing                                    ; 11b3: a9 04       ..
     ldx #4                                                            ; 11b5: a2 04       ..
     ldy #0                                                            ; 11b7: a0 00       ..
@@ -392,39 +426,39 @@ pydis_start
     ldy #0                                                            ; 1217: a0 00       ..
     jsr osbyte                                                        ; 1219: 20 f4 ff     ..            ; Set serial receive rate based on X
     lda #osbyte_set_serial_receive_rate                               ; 121c: a9 07       ..
-    ldx #0                                                            ; 121e: a2 00       ..
+    ldx #baud_rate_default_9600                                       ; 121e: a2 00       ..
     ldy #0                                                            ; 1220: a0 00       ..
-    jsr osbyte                                                        ; 1222: 20 f4 ff     ..            ; Set serial receive rate to 9600 baud (X=0)
+    jsr osbyte                                                        ; 1222: 20 f4 ff     ..            ; Set serial receive rate to default 9600 baud (X=0)
     lda #osbyte_set_serial_receive_rate                               ; 1225: a9 07       ..
-    ldx #1                                                            ; 1227: a2 01       ..
+    ldx #baud_rate_75                                                 ; 1227: a2 01       ..
     ldy #0                                                            ; 1229: a0 00       ..
     jsr osbyte                                                        ; 122b: 20 f4 ff     ..            ; Set serial receive rate to 75 baud (X=1)
     lda #osbyte_set_serial_receive_rate                               ; 122e: a9 07       ..
-    ldx #2                                                            ; 1230: a2 02       ..
+    ldx #baud_rate_150                                                ; 1230: a2 02       ..
     ldy #0                                                            ; 1232: a0 00       ..
     jsr osbyte                                                        ; 1234: 20 f4 ff     ..            ; Set serial receive rate to 150 baud (X=2)
     lda #osbyte_set_serial_receive_rate                               ; 1237: a9 07       ..
-    ldx #3                                                            ; 1239: a2 03       ..
+    ldx #baud_rate_300                                                ; 1239: a2 03       ..
     ldy #0                                                            ; 123b: a0 00       ..
     jsr osbyte                                                        ; 123d: 20 f4 ff     ..            ; Set serial receive rate to 300 baud (X=3)
     lda #osbyte_set_serial_receive_rate                               ; 1240: a9 07       ..
-    ldx #4                                                            ; 1242: a2 04       ..
+    ldx #baud_rate_1200                                               ; 1242: a2 04       ..
     ldy #0                                                            ; 1244: a0 00       ..
     jsr osbyte                                                        ; 1246: 20 f4 ff     ..            ; Set serial receive rate to 1200 baud (X=4)
     lda #osbyte_set_serial_receive_rate                               ; 1249: a9 07       ..
-    ldx #5                                                            ; 124b: a2 05       ..
+    ldx #baud_rate_2400                                               ; 124b: a2 05       ..
     ldy #0                                                            ; 124d: a0 00       ..
     jsr osbyte                                                        ; 124f: 20 f4 ff     ..            ; Set serial receive rate to 2400 baud (X=5)
     lda #osbyte_set_serial_receive_rate                               ; 1252: a9 07       ..
-    ldx #6                                                            ; 1254: a2 06       ..
+    ldx #baud_rate_4800                                               ; 1254: a2 06       ..
     ldy #0                                                            ; 1256: a0 00       ..
     jsr osbyte                                                        ; 1258: 20 f4 ff     ..            ; Set serial receive rate to 4800 baud (X=6)
     lda #osbyte_set_serial_receive_rate                               ; 125b: a9 07       ..
-    ldx #7                                                            ; 125d: a2 07       ..
+    ldx #baud_rate_9600                                               ; 125d: a2 07       ..
     ldy #0                                                            ; 125f: a0 00       ..
     jsr osbyte                                                        ; 1261: 20 f4 ff     ..            ; Set serial receive rate to 9600 baud (X=7)
     lda #osbyte_set_serial_receive_rate                               ; 1264: a9 07       ..
-    ldx #8                                                            ; 1266: a2 08       ..
+    ldx #baud_rate_19200                                              ; 1266: a2 08       ..
     ldy #0                                                            ; 1268: a0 00       ..
     jsr osbyte                                                        ; 126a: 20 f4 ff     ..            ; Set serial receive rate to 19200 baud (X=8)
     lda #osbyte_set_serial_receive_rate                               ; 126d: a9 07       ..
@@ -446,39 +480,39 @@ pydis_start
     ldy #0                                                            ; 127e: a0 00       ..
     jsr osbyte                                                        ; 1280: 20 f4 ff     ..            ; Set serial transmission rate based on X
     lda #osbyte_set_serial_transmit_rate                              ; 1283: a9 08       ..
-    ldx #0                                                            ; 1285: a2 00       ..
+    ldx #baud_rate_default_9600                                       ; 1285: a2 00       ..
     ldy #0                                                            ; 1287: a0 00       ..
-    jsr osbyte                                                        ; 1289: 20 f4 ff     ..            ; Set serial transmission rate to 9600 baud (X=0)
+    jsr osbyte                                                        ; 1289: 20 f4 ff     ..            ; Set serial transmission rate to default 9600 baud (X=0)
     lda #osbyte_set_serial_transmit_rate                              ; 128c: a9 08       ..
-    ldx #1                                                            ; 128e: a2 01       ..
+    ldx #baud_rate_75                                                 ; 128e: a2 01       ..
     ldy #0                                                            ; 1290: a0 00       ..
     jsr osbyte                                                        ; 1292: 20 f4 ff     ..            ; Set serial transmission rate to 75 baud (X=1)
     lda #osbyte_set_serial_transmit_rate                              ; 1295: a9 08       ..
-    ldx #2                                                            ; 1297: a2 02       ..
+    ldx #baud_rate_150                                                ; 1297: a2 02       ..
     ldy #0                                                            ; 1299: a0 00       ..
     jsr osbyte                                                        ; 129b: 20 f4 ff     ..            ; Set serial transmission rate to 150 baud (X=2)
     lda #osbyte_set_serial_transmit_rate                              ; 129e: a9 08       ..
-    ldx #3                                                            ; 12a0: a2 03       ..
+    ldx #baud_rate_300                                                ; 12a0: a2 03       ..
     ldy #0                                                            ; 12a2: a0 00       ..
     jsr osbyte                                                        ; 12a4: 20 f4 ff     ..            ; Set serial transmission rate to 300 baud (X=3)
     lda #osbyte_set_serial_transmit_rate                              ; 12a7: a9 08       ..
-    ldx #4                                                            ; 12a9: a2 04       ..
+    ldx #baud_rate_1200                                               ; 12a9: a2 04       ..
     ldy #0                                                            ; 12ab: a0 00       ..
     jsr osbyte                                                        ; 12ad: 20 f4 ff     ..            ; Set serial transmission rate to 1200 baud (X=4)
     lda #osbyte_set_serial_transmit_rate                              ; 12b0: a9 08       ..
-    ldx #5                                                            ; 12b2: a2 05       ..
+    ldx #baud_rate_2400                                               ; 12b2: a2 05       ..
     ldy #0                                                            ; 12b4: a0 00       ..
     jsr osbyte                                                        ; 12b6: 20 f4 ff     ..            ; Set serial transmission rate to 2400 baud (X=5)
     lda #osbyte_set_serial_transmit_rate                              ; 12b9: a9 08       ..
-    ldx #6                                                            ; 12bb: a2 06       ..
+    ldx #baud_rate_4800                                               ; 12bb: a2 06       ..
     ldy #0                                                            ; 12bd: a0 00       ..
     jsr osbyte                                                        ; 12bf: 20 f4 ff     ..            ; Set serial transmission rate to 4800 baud (X=6)
     lda #osbyte_set_serial_transmit_rate                              ; 12c2: a9 08       ..
-    ldx #7                                                            ; 12c4: a2 07       ..
+    ldx #baud_rate_9600                                               ; 12c4: a2 07       ..
     ldy #0                                                            ; 12c6: a0 00       ..
     jsr osbyte                                                        ; 12c8: 20 f4 ff     ..            ; Set serial transmission rate to 9600 baud (X=7)
     lda #osbyte_set_serial_transmit_rate                              ; 12cb: a9 08       ..
-    ldx #8                                                            ; 12cd: a2 08       ..
+    ldx #baud_rate_19200                                              ; 12cd: a2 08       ..
     ldy #0                                                            ; 12cf: a0 00       ..
     jsr osbyte                                                        ; 12d1: 20 f4 ff     ..            ; Set serial transmission rate to 19200 baud (X=8)
     lda #osbyte_set_serial_transmit_rate                              ; 12d4: a9 08       ..
@@ -571,43 +605,43 @@ pydis_start
 
     ; *************** Test OSBYTE 0x0d ***************
     lda #osbyte_disable_event                                         ; 1377: a9 0d       ..
-    ldx #0                                                            ; 1379: a2 00       ..
+    ldx #event_output_buffer_empty                                    ; 1379: a2 00       ..
     ldy #0                                                            ; 137b: a0 00       ..
     jsr osbyte                                                        ; 137d: 20 f4 ff     ..            ; Disable 'Output buffer empty' event (X=0)
     lda #osbyte_disable_event                                         ; 1380: a9 0d       ..
-    ldx #1                                                            ; 1382: a2 01       ..
+    ldx #event_input_buffer_full                                      ; 1382: a2 01       ..
     ldy #0                                                            ; 1384: a0 00       ..
     jsr osbyte                                                        ; 1386: 20 f4 ff     ..            ; Disable 'Input buffer full' event (X=1)
     lda #osbyte_disable_event                                         ; 1389: a9 0d       ..
-    ldx #2                                                            ; 138b: a2 02       ..
+    ldx #event_character_entering_input_buffer                        ; 138b: a2 02       ..
     ldy #0                                                            ; 138d: a0 00       ..
     jsr osbyte                                                        ; 138f: 20 f4 ff     ..            ; Disable 'Character entering input buffer' event (X=2)
     lda #osbyte_disable_event                                         ; 1392: a9 0d       ..
-    ldx #3                                                            ; 1394: a2 03       ..
+    ldx #event_adc_conversion_complete                                ; 1394: a2 03       ..
     ldy #0                                                            ; 1396: a0 00       ..
     jsr osbyte                                                        ; 1398: 20 f4 ff     ..            ; Disable 'ADC conversion complete' event (X=3)
     lda #osbyte_disable_event                                         ; 139b: a9 0d       ..
-    ldx #4                                                            ; 139d: a2 04       ..
+    ldx #event_start_of_vertical_sync                                 ; 139d: a2 04       ..
     ldy #0                                                            ; 139f: a0 00       ..
     jsr osbyte                                                        ; 13a1: 20 f4 ff     ..            ; Disable 'Start of vertical sync' event (X=4)
     lda #osbyte_disable_event                                         ; 13a4: a9 0d       ..
-    ldx #5                                                            ; 13a6: a2 05       ..
+    ldx #event_interval_timer_crossing_zero                           ; 13a6: a2 05       ..
     ldy #0                                                            ; 13a8: a0 00       ..
     jsr osbyte                                                        ; 13aa: 20 f4 ff     ..            ; Disable 'Interval timer crossing zero' event (X=5)
     lda #osbyte_disable_event                                         ; 13ad: a9 0d       ..
-    ldx #6                                                            ; 13af: a2 06       ..
+    ldx #event_escape_condition_detected                              ; 13af: a2 06       ..
     ldy #0                                                            ; 13b1: a0 00       ..
     jsr osbyte                                                        ; 13b3: 20 f4 ff     ..            ; Disable 'ESCAPE condition detected' event (X=6)
     lda #osbyte_disable_event                                         ; 13b6: a9 0d       ..
-    ldx #7                                                            ; 13b8: a2 07       ..
+    ldx #event_rs423_error                                            ; 13b8: a2 07       ..
     ldy #0                                                            ; 13ba: a0 00       ..
     jsr osbyte                                                        ; 13bc: 20 f4 ff     ..            ; Disable 'RS423 error' event (X=7)
     lda #osbyte_disable_event                                         ; 13bf: a9 0d       ..
-    ldx #8                                                            ; 13c1: a2 08       ..
+    ldx #event_network_error                                          ; 13c1: a2 08       ..
     ldy #0                                                            ; 13c3: a0 00       ..
     jsr osbyte                                                        ; 13c5: 20 f4 ff     ..            ; Disable 'Network error' event (X=8)
     lda #osbyte_disable_event                                         ; 13c8: a9 0d       ..
-    ldx #9                                                            ; 13ca: a2 09       ..
+    ldx #event_user                                                   ; 13ca: a2 09       ..
     ldy #0                                                            ; 13cc: a0 00       ..
     jsr osbyte                                                        ; 13ce: 20 f4 ff     ..            ; Disable 'User' event (X=9)
     lda #osbyte_disable_event                                         ; 13d1: a9 0d       ..
@@ -618,43 +652,43 @@ pydis_start
 
     ; *************** Test OSBYTE 0x0e ***************
     lda #osbyte_enable_event                                          ; 13dc: a9 0e       ..
-    ldx #0                                                            ; 13de: a2 00       ..
+    ldx #event_output_buffer_empty                                    ; 13de: a2 00       ..
     ldy #0                                                            ; 13e0: a0 00       ..
     jsr osbyte                                                        ; 13e2: 20 f4 ff     ..            ; Enable 'Output buffer empty' event (X=0)
     lda #osbyte_enable_event                                          ; 13e5: a9 0e       ..
-    ldx #1                                                            ; 13e7: a2 01       ..
+    ldx #event_input_buffer_full                                      ; 13e7: a2 01       ..
     ldy #0                                                            ; 13e9: a0 00       ..
     jsr osbyte                                                        ; 13eb: 20 f4 ff     ..            ; Enable 'Input buffer full' event (X=1)
     lda #osbyte_enable_event                                          ; 13ee: a9 0e       ..
-    ldx #2                                                            ; 13f0: a2 02       ..
+    ldx #event_character_entering_input_buffer                        ; 13f0: a2 02       ..
     ldy #0                                                            ; 13f2: a0 00       ..
     jsr osbyte                                                        ; 13f4: 20 f4 ff     ..            ; Enable 'Character entering input buffer' event (X=2)
     lda #osbyte_enable_event                                          ; 13f7: a9 0e       ..
-    ldx #3                                                            ; 13f9: a2 03       ..
+    ldx #event_adc_conversion_complete                                ; 13f9: a2 03       ..
     ldy #0                                                            ; 13fb: a0 00       ..
     jsr osbyte                                                        ; 13fd: 20 f4 ff     ..            ; Enable 'ADC conversion complete' event (X=3)
     lda #osbyte_enable_event                                          ; 1400: a9 0e       ..
-    ldx #4                                                            ; 1402: a2 04       ..
+    ldx #event_start_of_vertical_sync                                 ; 1402: a2 04       ..
     ldy #0                                                            ; 1404: a0 00       ..
     jsr osbyte                                                        ; 1406: 20 f4 ff     ..            ; Enable 'Start of vertical sync' event (X=4)
     lda #osbyte_enable_event                                          ; 1409: a9 0e       ..
-    ldx #5                                                            ; 140b: a2 05       ..
+    ldx #event_interval_timer_crossing_zero                           ; 140b: a2 05       ..
     ldy #0                                                            ; 140d: a0 00       ..
     jsr osbyte                                                        ; 140f: 20 f4 ff     ..            ; Enable 'Interval timer crossing zero' event (X=5)
     lda #osbyte_enable_event                                          ; 1412: a9 0e       ..
-    ldx #6                                                            ; 1414: a2 06       ..
+    ldx #event_escape_condition_detected                              ; 1414: a2 06       ..
     ldy #0                                                            ; 1416: a0 00       ..
     jsr osbyte                                                        ; 1418: 20 f4 ff     ..            ; Enable 'ESCAPE condition detected' event (X=6)
     lda #osbyte_enable_event                                          ; 141b: a9 0e       ..
-    ldx #7                                                            ; 141d: a2 07       ..
+    ldx #event_rs423_error                                            ; 141d: a2 07       ..
     ldy #0                                                            ; 141f: a0 00       ..
     jsr osbyte                                                        ; 1421: 20 f4 ff     ..            ; Enable 'RS423 error' event (X=7)
     lda #osbyte_enable_event                                          ; 1424: a9 0e       ..
-    ldx #8                                                            ; 1426: a2 08       ..
+    ldx #event_network_error                                          ; 1426: a2 08       ..
     ldy #0                                                            ; 1428: a0 00       ..
     jsr osbyte                                                        ; 142a: 20 f4 ff     ..            ; Enable 'Network error' event (X=8)
     lda #osbyte_enable_event                                          ; 142d: a9 0e       ..
-    ldx #9                                                            ; 142f: a2 09       ..
+    ldx #event_user                                                   ; 142f: a2 09       ..
     ldy #0                                                            ; 1431: a0 00       ..
     jsr osbyte                                                        ; 1433: 20 f4 ff     ..            ; Enable 'User' event (X=9)
     lda #osbyte_enable_event                                          ; 1436: a9 0e       ..
@@ -771,39 +805,39 @@ pydis_start
     ldy #0                                                            ; 150f: a0 00       ..
     jsr osbyte                                                        ; 1511: 20 f4 ff     ..            ; Flush specific buffer X
     lda #osbyte_flush_buffer                                          ; 1514: a9 15       ..
-    ldx #0                                                            ; 1516: a2 00       ..
+    ldx #buffer_keyboard                                              ; 1516: a2 00       ..
     ldy #0                                                            ; 1518: a0 00       ..
     jsr osbyte                                                        ; 151a: 20 f4 ff     ..            ; Flush the keyboard buffer (X=0)
     lda #osbyte_flush_buffer                                          ; 151d: a9 15       ..
-    ldx #1                                                            ; 151f: a2 01       ..
+    ldx #buffer_rs423_input                                           ; 151f: a2 01       ..
     ldy #0                                                            ; 1521: a0 00       ..
     jsr osbyte                                                        ; 1523: 20 f4 ff     ..            ; Flush the RS423 input buffer (X=1)
     lda #osbyte_flush_buffer                                          ; 1526: a9 15       ..
-    ldx #2                                                            ; 1528: a2 02       ..
+    ldx #buffer_rs423_output                                          ; 1528: a2 02       ..
     ldy #0                                                            ; 152a: a0 00       ..
     jsr osbyte                                                        ; 152c: 20 f4 ff     ..            ; Flush the RS423 output buffer (X=2)
     lda #osbyte_flush_buffer                                          ; 152f: a9 15       ..
-    ldx #3                                                            ; 1531: a2 03       ..
+    ldx #buffer_printer                                               ; 1531: a2 03       ..
     ldy #0                                                            ; 1533: a0 00       ..
     jsr osbyte                                                        ; 1535: 20 f4 ff     ..            ; Flush the printer buffer (X=3)
     lda #osbyte_flush_buffer                                          ; 1538: a9 15       ..
-    ldx #4                                                            ; 153a: a2 04       ..
+    ldx #buffer_sound_channel_0                                       ; 153a: a2 04       ..
     ldy #0                                                            ; 153c: a0 00       ..
     jsr osbyte                                                        ; 153e: 20 f4 ff     ..            ; Flush sound channel 0 (X=4)
     lda #osbyte_flush_buffer                                          ; 1541: a9 15       ..
-    ldx #5                                                            ; 1543: a2 05       ..
+    ldx #buffer_sound_channel_1                                       ; 1543: a2 05       ..
     ldy #0                                                            ; 1545: a0 00       ..
     jsr osbyte                                                        ; 1547: 20 f4 ff     ..            ; Flush sound channel 1 (X=5)
     lda #osbyte_flush_buffer                                          ; 154a: a9 15       ..
-    ldx #6                                                            ; 154c: a2 06       ..
+    ldx #buffer_sound_channel_2                                       ; 154c: a2 06       ..
     ldy #0                                                            ; 154e: a0 00       ..
     jsr osbyte                                                        ; 1550: 20 f4 ff     ..            ; Flush sound channel 2 (X=6)
     lda #osbyte_flush_buffer                                          ; 1553: a9 15       ..
-    ldx #7                                                            ; 1555: a2 07       ..
+    ldx #buffer_sound_channel_3                                       ; 1555: a2 07       ..
     ldy #0                                                            ; 1557: a0 00       ..
     jsr osbyte                                                        ; 1559: 20 f4 ff     ..            ; Flush sound channel 3 (X=7)
     lda #osbyte_flush_buffer                                          ; 155c: a9 15       ..
-    ldx #8                                                            ; 155e: a2 08       ..
+    ldx #buffer_speech                                                ; 155e: a2 08       ..
     ldy #0                                                            ; 1560: a0 00       ..
     jsr osbyte                                                        ; 1562: 20 f4 ff     ..            ; Flush the speech buffer (X=8)
     lda #osbyte_flush_buffer                                          ; 1565: a9 15       ..
@@ -931,15 +965,15 @@ pydis_start
     jsr osbyte                                                        ; 162d: 20 f4 ff     ..            ; Keyboard scan, or test for a specific key
     cpx #0                                                            ; 1630: e0 00       ..             ; X is either the internal key number (0-127) pressed (for a keyboard scan), or the top bit is the key state (when testing a specific key)
     lda #osbyte_scan_keyboard                                         ; 1632: a9 79       .y
-    ldx #0                                                            ; 1634: a2 00       ..
+    ldx #255 - inkey_key_shift                                        ; 1634: a2 00       ..             ; X=internal key number
     jsr osbyte                                                        ; 1636: 20 f4 ff     ..            ; Keyboard scan starting from 'SHIFT' key (X=0)
     cpx #0                                                            ; 1639: e0 00       ..             ; X is the internal key number (0-127) if a key is pressed, or $ff otherwise
     lda #osbyte_scan_keyboard                                         ; 163b: a9 79       .y
-    ldx #1                                                            ; 163d: a2 01       ..
+    ldx #255 - inkey_key_ctrl                                         ; 163d: a2 01       ..             ; X=internal key number
     jsr osbyte                                                        ; 163f: 20 f4 ff     ..            ; Keyboard scan starting from 'CTRL' key (X=1)
     cpx #0                                                            ; 1642: e0 00       ..             ; X is the internal key number (0-127) if a key is pressed, or $ff otherwise
     lda #osbyte_scan_keyboard                                         ; 1644: a9 79       .y
-    ldx #$80                                                          ; 1646: a2 80       ..
+    ldx #(255 - inkey_key_shift) XOR 128                              ; 1646: a2 80       ..             ; X=internal key number EOR 128
     jsr osbyte                                                        ; 1648: 20 f4 ff     ..            ; Test for 'SHIFT' key pressed (X=128)
     cpx #0                                                            ; 164b: e0 00       ..             ; X has top bit set if 'SHIFT' pressed
     lda #osbyte_scan_keyboard                                         ; 164d: a9 79       .y
@@ -947,7 +981,7 @@ pydis_start
     jsr osbyte                                                        ; 1651: 20 f4 ff     ..            ; Test for an unknown key pressed (X=255)
     cpx #0                                                            ; 1654: e0 00       ..             ; X has top bit set if an unknown pressed
     lda #osbyte_scan_keyboard                                         ; 1656: a9 79       .y
-    ldx #$20 ; ' '                                                    ; 1658: a2 20       .
+    ldx #255 - inkey_key_f0                                           ; 1658: a2 20       .              ; X=internal key number
     jsr osbyte                                                        ; 165a: 20 f4 ff     ..            ; Keyboard scan starting from 'F0' key (X=32)
     cpx #0                                                            ; 165d: e0 00       ..             ; X is the internal key number (0-127) if a key is pressed, or $ff otherwise
 
@@ -1115,7 +1149,7 @@ pydis_start
     ;     X=245, Master Compact OS 5.10
     cpx #0                                                            ; 178a: e0 00       ..
     lda #osbyte_inkey                                                 ; 178c: a9 81       ..
-    ldx #inkey_key_shift                                              ; 178e: a2 ff       ..
+    ldx #inkey_key_shift                                              ; 178e: a2 ff       ..             ; X=inkey key value
     ldy #$80                                                          ; 1790: a0 80       ..
     jsr osbyte                                                        ; 1792: 20 f4 ff     ..            ; Is the 'SHIFT' key pressed?
     cpy #0                                                            ; 1795: c0 00       ..             ; X and Y contain $ff if the key is pressed
@@ -1246,43 +1280,43 @@ pydis_start
     ldy #0                                                            ; 1881: a0 00       ..
     jsr osbyte                                                        ; 1883: 20 f4 ff     ..            ; Insert value 0 into buffer X; carry is clear if successful
     lda #osbyte_insert_buffer                                         ; 1886: a9 8a       ..
-    ldx #1                                                            ; 1888: a2 01       ..
+    ldx #buffer_rs423_input                                           ; 1888: a2 01       ..
     ldy mem                                                           ; 188a: a4 70       .p
     jsr osbyte                                                        ; 188c: 20 f4 ff     ..            ; Insert value Y into the RS423 input buffer (X=1); carry is clear if successful
     lda #osbyte_insert_buffer                                         ; 188f: a9 8a       ..
-    ldx #0                                                            ; 1891: a2 00       ..
+    ldx #buffer_keyboard                                              ; 1891: a2 00       ..
     ldy #2                                                            ; 1893: a0 02       ..
     jsr osbyte                                                        ; 1895: 20 f4 ff     ..            ; Insert value 2 into the keyboard buffer (X=0); carry is clear if successful
     lda #osbyte_insert_buffer                                         ; 1898: a9 8a       ..
-    ldx #1                                                            ; 189a: a2 01       ..
+    ldx #buffer_rs423_input                                           ; 189a: a2 01       ..
     ldy #3                                                            ; 189c: a0 03       ..
     jsr osbyte                                                        ; 189e: 20 f4 ff     ..            ; Insert value 3 into the RS423 input buffer (X=1); carry is clear if successful
     lda #osbyte_insert_buffer                                         ; 18a1: a9 8a       ..
-    ldx #2                                                            ; 18a3: a2 02       ..
+    ldx #buffer_rs423_output                                          ; 18a3: a2 02       ..
     ldy #$63 ; 'c'                                                    ; 18a5: a0 63       .c
     jsr osbyte                                                        ; 18a7: 20 f4 ff     ..            ; Insert value 99 into the RS423 output buffer (X=2); carry is clear if successful
     lda #osbyte_insert_buffer                                         ; 18aa: a9 8a       ..
-    ldx #3                                                            ; 18ac: a2 03       ..
+    ldx #buffer_printer                                               ; 18ac: a2 03       ..
     ldy #$17                                                          ; 18ae: a0 17       ..
     jsr osbyte                                                        ; 18b0: 20 f4 ff     ..            ; Insert value 23 into the printer buffer (X=3); carry is clear if successful
     lda #osbyte_insert_buffer                                         ; 18b3: a9 8a       ..
-    ldx #4                                                            ; 18b5: a2 04       ..
+    ldx #buffer_sound_channel_0                                       ; 18b5: a2 04       ..
     ldy #$ce                                                          ; 18b7: a0 ce       ..
     jsr osbyte                                                        ; 18b9: 20 f4 ff     ..            ; Insert value 206 into sound channel 0 (X=4); carry is clear if successful
     lda #osbyte_insert_buffer                                         ; 18bc: a9 8a       ..
-    ldx #5                                                            ; 18be: a2 05       ..
+    ldx #buffer_sound_channel_1                                       ; 18be: a2 05       ..
     ldy #$63 ; 'c'                                                    ; 18c0: a0 63       .c
     jsr osbyte                                                        ; 18c2: 20 f4 ff     ..            ; Insert value 99 into sound channel 1 (X=5); carry is clear if successful
     lda #osbyte_insert_buffer                                         ; 18c5: a9 8a       ..
-    ldx #6                                                            ; 18c7: a2 06       ..
+    ldx #buffer_sound_channel_2                                       ; 18c7: a2 06       ..
     ldy #$2a ; '*'                                                    ; 18c9: a0 2a       .*
     jsr osbyte                                                        ; 18cb: 20 f4 ff     ..            ; Insert value 42 into sound channel 2 (X=6); carry is clear if successful
     lda #osbyte_insert_buffer                                         ; 18ce: a9 8a       ..
-    ldx #7                                                            ; 18d0: a2 07       ..
+    ldx #buffer_sound_channel_3                                       ; 18d0: a2 07       ..
     ldy #1                                                            ; 18d2: a0 01       ..
     jsr osbyte                                                        ; 18d4: 20 f4 ff     ..            ; Insert value 1 into sound channel 3 (X=7); carry is clear if successful
     lda #osbyte_insert_buffer                                         ; 18d7: a9 8a       ..
-    ldx #8                                                            ; 18d9: a2 08       ..
+    ldx #buffer_speech                                                ; 18d9: a2 08       ..
     ldy #$5a ; 'Z'                                                    ; 18db: a0 5a       .Z
     jsr osbyte                                                        ; 18dd: 20 f4 ff     ..            ; Insert value 90 into the speech buffer (X=8); carry is clear if successful
     lda #osbyte_insert_buffer                                         ; 18e0: a9 8a       ..
@@ -1638,7 +1672,7 @@ pydis_start
 
     ; *************** Test OSBYTE 0x91 ***************
     lda #osbyte_read_buffer                                           ; 1bd8: a9 91       ..
-    ldx #0                                                            ; 1bda: a2 00       ..
+    ldx #buffer_keyboard                                              ; 1bda: a2 00       ..
     ldy #0                                                            ; 1bdc: a0 00       ..
     jsr osbyte                                                        ; 1bde: 20 f4 ff     ..            ; Get character from keyboard buffer (C is set if the buffer is empty, otherwise Y=extracted character)
     bcs buffer_empty                                                  ; 1be1: b0 02       ..
@@ -1733,31 +1767,31 @@ buffer_empty
     ldy #0                                                            ; 1c85: a0 00       ..
     jsr osbyte                                                        ; 1c87: 20 f4 ff     ..            ; Examine status of buffer X (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        ; 1c8a: a9 98       ..
-    ldx #0                                                            ; 1c8c: a2 00       ..
+    ldx #buffer_keyboard                                              ; 1c8c: a2 00       ..
     jsr osbyte                                                        ; 1c8e: 20 f4 ff     ..            ; Examine the keyboard buffer (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        ; 1c91: a9 98       ..
-    ldx #1                                                            ; 1c93: a2 01       ..
+    ldx #buffer_rs423_input                                           ; 1c93: a2 01       ..
     jsr osbyte                                                        ; 1c95: 20 f4 ff     ..            ; Examine the RS423 input buffer (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        ; 1c98: a9 98       ..
-    ldx #2                                                            ; 1c9a: a2 02       ..
+    ldx #buffer_rs423_output                                          ; 1c9a: a2 02       ..
     jsr osbyte                                                        ; 1c9c: 20 f4 ff     ..            ; Examine the RS423 output buffer (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        ; 1c9f: a9 98       ..
-    ldx #3                                                            ; 1ca1: a2 03       ..
+    ldx #buffer_printer                                               ; 1ca1: a2 03       ..
     jsr osbyte                                                        ; 1ca3: 20 f4 ff     ..            ; Examine the printer buffer (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        ; 1ca6: a9 98       ..
-    ldx #4                                                            ; 1ca8: a2 04       ..
+    ldx #buffer_sound_channel_0                                       ; 1ca8: a2 04       ..
     jsr osbyte                                                        ; 1caa: 20 f4 ff     ..            ; Examine sound channel 0 (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        ; 1cad: a9 98       ..
-    ldx #5                                                            ; 1caf: a2 05       ..
+    ldx #buffer_sound_channel_1                                       ; 1caf: a2 05       ..
     jsr osbyte                                                        ; 1cb1: 20 f4 ff     ..            ; Examine sound channel 1 (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        ; 1cb4: a9 98       ..
-    ldx #6                                                            ; 1cb6: a2 06       ..
+    ldx #buffer_sound_channel_2                                       ; 1cb6: a2 06       ..
     jsr osbyte                                                        ; 1cb8: 20 f4 ff     ..            ; Examine sound channel 2 (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        ; 1cbb: a9 98       ..
-    ldx #7                                                            ; 1cbd: a2 07       ..
+    ldx #buffer_sound_channel_3                                       ; 1cbd: a2 07       ..
     jsr osbyte                                                        ; 1cbf: 20 f4 ff     ..            ; Examine sound channel 3 (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        ; 1cc2: a9 98       ..
-    ldx #8                                                            ; 1cc4: a2 08       ..
+    ldx #buffer_speech                                                ; 1cc4: a2 08       ..
     jsr osbyte                                                        ; 1cc6: 20 f4 ff     ..            ; Examine the speech buffer (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        ; 1cc9: a9 98       ..
     ldx #9                                                            ; 1ccb: a2 09       ..
@@ -4456,29 +4490,29 @@ buffer_empty
     lda #4                                                            ; 31ba: a9 04       ..             ; A=value to be written
     ldy #$5a ; 'Z'                                                    ; 31bc: a0 5a       .Z             ; Y=offset from base address
     jsr oswrsc                                                        ; 31be: 20 b3 ff     ..            ; Write byte to screen
-    ldy #2                                                            ; 31c1: a0 02       ..
+    ldy #event_character_entering_input_buffer                        ; 31c1: a0 02       ..
     jsr oseven                                                        ; 31c3: 20 bf ff     ..            ; Generate event Y='Character entering input buffer'
     jsr osrdch                                                        ; 31c6: 20 e0 ff     ..            ; Read a character from the current input stream
     cmp #$20 ; ' '                                                    ; 31c9: c9 20       .              ; A=character read
     jsr nvrdch                                                        ; 31cb: 20 c8 ff     ..            ; Read a character from the current input stream
     cmp #$2a ; '*'                                                    ; 31ce: c9 2a       .*             ; A=character read
-    lda #0                                                            ; 31d0: a9 00       ..
+    lda #osfind_close                                                 ; 31d0: a9 00       ..
     ldy #0                                                            ; 31d2: a0 00       ..
     jsr osfind                                                        ; 31d4: 20 ce ff     ..            ; Close all files (Y=0)
-    lda #0                                                            ; 31d7: a9 00       ..
+    lda #osfind_close                                                 ; 31d7: a9 00       ..
     ldy #1                                                            ; 31d9: a0 01       ..
     jsr osfind                                                        ; 31db: 20 ce ff     ..            ; Close file Y
-    lda #$40 ; '@'                                                    ; 31de: a9 40       .@
+    lda #osfind_open_input                                            ; 31de: a9 40       .@
     ldx #<(osfind_block)                                              ; 31e0: a2 c7       ..
     ldy #>(osfind_block)                                              ; 31e2: a0 41       .A
     jsr osfind                                                        ; 31e4: 20 ce ff     ..            ; Open file for input (A=64)
     sta mem                                                           ; 31e7: 85 70       .p             ; A=file handle (or zero on failure)
-    lda #$80                                                          ; 31e9: a9 80       ..
+    lda #osfind_open_output                                           ; 31e9: a9 80       ..
     ldx #<(osfind_block)                                              ; 31eb: a2 c7       ..
     ldy #>(osfind_block)                                              ; 31ed: a0 41       .A
     jsr osfind                                                        ; 31ef: 20 ce ff     ..            ; Open file for output (A=128)
     sta mem                                                           ; 31f2: 85 70       .p             ; A=file handle (or zero on failure)
-    lda #$c0                                                          ; 31f4: a9 c0       ..
+    lda #osfind_open_random_access                                    ; 31f4: a9 c0       ..
     ldx #<(osfind_block)                                              ; 31f6: a2 c7       ..
     ldy #>(osfind_block)                                              ; 31f8: a0 41       .A
     jsr osfind                                                        ; 31fa: 20 ce ff     ..            ; Open file for random access (A=192)
@@ -5832,6 +5866,18 @@ pydis_end
 ;     osnewl:         1
 ;     oswrcr:         1
 ;     oswrch:         1
+!if ((255 - inkey_key_shift) XOR 128) != $80 {
+    !error "Assertion failed: (255 - inkey_key_shift) XOR 128 == $80"
+}
+!if (255 - inkey_key_ctrl) != $01 {
+    !error "Assertion failed: 255 - inkey_key_ctrl == $01"
+}
+!if (255 - inkey_key_f0) != $20 {
+    !error "Assertion failed: 255 - inkey_key_f0 == $20"
+}
+!if (255 - inkey_key_shift) != $00 {
+    !error "Assertion failed: 255 - inkey_key_shift == $00"
+}
 !if (<(input_buffer)) != $05 {
     !error "Assertion failed: <(input_buffer) == $05"
 }
@@ -5963,6 +6009,90 @@ pydis_end
 }
 !if (>(osword9block)) != $40 {
     !error "Assertion failed: >(osword9block) == $40"
+}
+!if (baud_rate_1200) != $04 {
+    !error "Assertion failed: baud_rate_1200 == $04"
+}
+!if (baud_rate_150) != $02 {
+    !error "Assertion failed: baud_rate_150 == $02"
+}
+!if (baud_rate_19200) != $08 {
+    !error "Assertion failed: baud_rate_19200 == $08"
+}
+!if (baud_rate_2400) != $05 {
+    !error "Assertion failed: baud_rate_2400 == $05"
+}
+!if (baud_rate_300) != $03 {
+    !error "Assertion failed: baud_rate_300 == $03"
+}
+!if (baud_rate_4800) != $06 {
+    !error "Assertion failed: baud_rate_4800 == $06"
+}
+!if (baud_rate_75) != $01 {
+    !error "Assertion failed: baud_rate_75 == $01"
+}
+!if (baud_rate_9600) != $07 {
+    !error "Assertion failed: baud_rate_9600 == $07"
+}
+!if (baud_rate_default_9600) != $00 {
+    !error "Assertion failed: baud_rate_default_9600 == $00"
+}
+!if (buffer_keyboard) != $00 {
+    !error "Assertion failed: buffer_keyboard == $00"
+}
+!if (buffer_printer) != $03 {
+    !error "Assertion failed: buffer_printer == $03"
+}
+!if (buffer_rs423_input) != $01 {
+    !error "Assertion failed: buffer_rs423_input == $01"
+}
+!if (buffer_rs423_output) != $02 {
+    !error "Assertion failed: buffer_rs423_output == $02"
+}
+!if (buffer_sound_channel_0) != $04 {
+    !error "Assertion failed: buffer_sound_channel_0 == $04"
+}
+!if (buffer_sound_channel_1) != $05 {
+    !error "Assertion failed: buffer_sound_channel_1 == $05"
+}
+!if (buffer_sound_channel_2) != $06 {
+    !error "Assertion failed: buffer_sound_channel_2 == $06"
+}
+!if (buffer_sound_channel_3) != $07 {
+    !error "Assertion failed: buffer_sound_channel_3 == $07"
+}
+!if (buffer_speech) != $08 {
+    !error "Assertion failed: buffer_speech == $08"
+}
+!if (event_adc_conversion_complete) != $03 {
+    !error "Assertion failed: event_adc_conversion_complete == $03"
+}
+!if (event_character_entering_input_buffer) != $02 {
+    !error "Assertion failed: event_character_entering_input_buffer == $02"
+}
+!if (event_escape_condition_detected) != $06 {
+    !error "Assertion failed: event_escape_condition_detected == $06"
+}
+!if (event_input_buffer_full) != $01 {
+    !error "Assertion failed: event_input_buffer_full == $01"
+}
+!if (event_interval_timer_crossing_zero) != $05 {
+    !error "Assertion failed: event_interval_timer_crossing_zero == $05"
+}
+!if (event_network_error) != $08 {
+    !error "Assertion failed: event_network_error == $08"
+}
+!if (event_output_buffer_empty) != $00 {
+    !error "Assertion failed: event_output_buffer_empty == $00"
+}
+!if (event_rs423_error) != $07 {
+    !error "Assertion failed: event_rs423_error == $07"
+}
+!if (event_start_of_vertical_sync) != $04 {
+    !error "Assertion failed: event_start_of_vertical_sync == $04"
+}
+!if (event_user) != $09 {
+    !error "Assertion failed: event_user == $09"
 }
 !if (inkey_key_shift) != $ff {
     !error "Assertion failed: inkey_key_shift == $ff"
@@ -6497,6 +6627,18 @@ pydis_end
 }
 !if (osfile_write_load_addr) != $02 {
     !error "Assertion failed: osfile_write_load_addr == $02"
+}
+!if (osfind_close) != $00 {
+    !error "Assertion failed: osfind_close == $00"
+}
+!if (osfind_open_input) != $40 {
+    !error "Assertion failed: osfind_open_input == $40"
+}
+!if (osfind_open_output) != $80 {
+    !error "Assertion failed: osfind_open_output == $80"
+}
+!if (osfind_open_random_access) != $c0 {
+    !error "Assertion failed: osfind_open_random_access == $c0"
 }
 !if (osgbpb_append_bytes) != $02 {
     !error "Assertion failed: osgbpb_append_bytes == $02"

--- a/examples/known_good/acorn_os_calls_acme.asm
+++ b/examples/known_good/acorn_os_calls_acme.asm
@@ -78,7 +78,7 @@ osbyte_read_rom_info_table_high                    = 171
 osbyte_read_rom_info_table_low                     = 170
 osbyte_read_rom_ptr_table_high                     = 169
 osbyte_read_rom_ptr_table_low                      = 168
-osbyte_read_serial_control_flag                    = 192
+osbyte_read_serial_control_register_copy           = 192
 osbyte_read_serial_ula                             = 242
 osbyte_read_sheila                                 = 150
 osbyte_read_speech                                 = 158
@@ -106,28 +106,28 @@ osbyte_read_write_bell_channel                     = 211
 osbyte_read_write_bell_duration                    = 214
 osbyte_read_write_bell_envelope                    = 212
 osbyte_read_write_bell_frequency                   = 213
-osbyte_read_write_c0_cf_status                     = 221
 osbyte_read_write_cassette_serial_selection        = 205
 osbyte_read_write_cfs_rfs_switch                   = 183
 osbyte_read_write_cfs_timeout                      = 176
 osbyte_read_write_char_destination_status          = 236
+osbyte_read_write_characters_c0_cf_status          = 221
+osbyte_read_write_characters_d0_df_status          = 222
+osbyte_read_write_characters_e0_ef_status          = 223
+osbyte_read_write_characters_f0_ff_status          = 224
 osbyte_read_write_ctrl_function_key_status         = 227
 osbyte_read_write_ctrl_shift_function_key_status   = 228
 osbyte_read_write_current_language_rom_bank        = 252
 osbyte_read_write_current_oshwm                    = 180
 osbyte_read_write_cursor_editing_status            = 237
-osbyte_read_write_d0_df_status                     = 222
-osbyte_read_write_e0_ef_status                     = 223
 osbyte_read_write_econet_keyboard_disable          = 201
 osbyte_read_write_econet_os_call_interception      = 206
 osbyte_read_write_econet_osrdch_interception       = 207
 osbyte_read_write_econet_oswrch_interception       = 208
 osbyte_read_write_escape_break_effect              = 200
 osbyte_read_write_escape_char                      = 220
-osbyte_read_write_escape_flags                     = 230
+osbyte_read_write_escape_effects                   = 230
 osbyte_read_write_escape_status                    = 229
 osbyte_read_write_exec_file_handle                 = 198
-osbyte_read_write_f0_ff_status                     = 224
 osbyte_read_write_first_byte_break_intercept       = 247
 osbyte_read_write_flash_counter                    = 193
 osbyte_read_write_function_key_status              = 225
@@ -141,7 +141,7 @@ osbyte_read_write_lines_since_last_page            = 217
 osbyte_read_write_mark_count                       = 194
 osbyte_read_write_max_adc_channel                  = 189
 osbyte_read_write_primary_oshwm                    = 179
-osbyte_read_write_printer_destination_flag         = 245
+osbyte_read_write_printer_destination              = 245
 osbyte_read_write_printer_ignore_char              = 246
 osbyte_read_write_rom_bank_at_last_brk             = 186
 osbyte_read_write_second_byte_break_intercept      = 248
@@ -3484,13 +3484,13 @@ buffer_empty
     sty mem                                                           ; 2a98: 84 70       .p             ; Y=value of OS copy of 6850 (ACIA) control register
 
     ; *************** Test OSBYTE 0xc0 ***************
-    lda #osbyte_read_serial_control_flag                              ; 2a9a: a9 c0       ..
+    lda #osbyte_read_serial_control_register_copy                     ; 2a9a: a9 c0       ..
     ldx #$2a ; '*'                                                    ; 2a9c: a2 2a       .*
     ldy #0                                                            ; 2a9e: a0 00       ..
     jsr osbyte                                                        ; 2aa0: 20 f4 ff     ..            ; Write OS copy of 6850 (ACIA) control register, value X=42
     stx mem                                                           ; 2aa3: 86 70       .p             ; X=old value of OS copy of 6850 (ACIA) control register
     sty mem                                                           ; 2aa5: 84 70       .p             ; Y=value of flash counter in fiftieths of a second
-    lda #osbyte_read_serial_control_flag                              ; 2aa7: a9 c0       ..
+    lda #osbyte_read_serial_control_register_copy                     ; 2aa7: a9 c0       ..
     ldx #0                                                            ; 2aa9: a2 00       ..
     ldy #$ff                                                          ; 2aab: a0 ff       ..
     jsr osbyte                                                        ; 2aad: 20 f4 ff     ..            ; Read OS copy of 6850 (ACIA) control register
@@ -3890,13 +3890,13 @@ buffer_empty
     sty mem                                                           ; 2d8a: 84 70       .p             ; Y=value of character status flag ($c0-$cf)
 
     ; *************** Test OSBYTE 0xdd ***************
-    lda #osbyte_read_write_c0_cf_status                               ; 2d8c: a9 dd       ..
+    lda #osbyte_read_write_characters_c0_cf_status                    ; 2d8c: a9 dd       ..
     ldx #$2a ; '*'                                                    ; 2d8e: a2 2a       .*
     ldy #0                                                            ; 2d90: a0 00       ..
     jsr osbyte                                                        ; 2d92: 20 f4 ff     ..            ; Write character status flag ($c0-$cf), value X=42
     stx mem                                                           ; 2d95: 86 70       .p             ; X=old value of character status flag ($c0-$cf)
     sty mem                                                           ; 2d97: 84 70       .p             ; Y=value of character status flag ($d0-$df)
-    lda #osbyte_read_write_c0_cf_status                               ; 2d99: a9 dd       ..
+    lda #osbyte_read_write_characters_c0_cf_status                    ; 2d99: a9 dd       ..
     ldx #0                                                            ; 2d9b: a2 00       ..
     ldy #$ff                                                          ; 2d9d: a0 ff       ..
     jsr osbyte                                                        ; 2d9f: 20 f4 ff     ..            ; Read character status flag ($c0-$cf)
@@ -3904,13 +3904,13 @@ buffer_empty
     sty mem                                                           ; 2da4: 84 70       .p             ; Y=value of character status flag ($d0-$df)
 
     ; *************** Test OSBYTE 0xde ***************
-    lda #osbyte_read_write_d0_df_status                               ; 2da6: a9 de       ..
+    lda #osbyte_read_write_characters_d0_df_status                    ; 2da6: a9 de       ..
     ldx #$2a ; '*'                                                    ; 2da8: a2 2a       .*
     ldy #0                                                            ; 2daa: a0 00       ..
     jsr osbyte                                                        ; 2dac: 20 f4 ff     ..            ; Write character status flag ($d0-$df), value X=42
     stx mem                                                           ; 2daf: 86 70       .p             ; X=old value of character status flag ($d0-$df)
     sty mem                                                           ; 2db1: 84 70       .p             ; Y=value of character status flag ($e0-$ef)
-    lda #osbyte_read_write_d0_df_status                               ; 2db3: a9 de       ..
+    lda #osbyte_read_write_characters_d0_df_status                    ; 2db3: a9 de       ..
     ldx #0                                                            ; 2db5: a2 00       ..
     ldy #$ff                                                          ; 2db7: a0 ff       ..
     jsr osbyte                                                        ; 2db9: 20 f4 ff     ..            ; Read character status flag ($d0-$df)
@@ -3918,13 +3918,13 @@ buffer_empty
     sty mem                                                           ; 2dbe: 84 70       .p             ; Y=value of character status flag ($e0-$ef)
 
     ; *************** Test OSBYTE 0xdf ***************
-    lda #osbyte_read_write_e0_ef_status                               ; 2dc0: a9 df       ..
+    lda #osbyte_read_write_characters_e0_ef_status                    ; 2dc0: a9 df       ..
     ldx #$2a ; '*'                                                    ; 2dc2: a2 2a       .*
     ldy #0                                                            ; 2dc4: a0 00       ..
     jsr osbyte                                                        ; 2dc6: 20 f4 ff     ..            ; Write character status flag ($e0-$ef), value X=42
     stx mem                                                           ; 2dc9: 86 70       .p             ; X=old value of character status flag ($e0-$ef)
     sty mem                                                           ; 2dcb: 84 70       .p             ; Y=value of character status flag ($f0-$ff)
-    lda #osbyte_read_write_e0_ef_status                               ; 2dcd: a9 df       ..
+    lda #osbyte_read_write_characters_e0_ef_status                    ; 2dcd: a9 df       ..
     ldx #0                                                            ; 2dcf: a2 00       ..
     ldy #$ff                                                          ; 2dd1: a0 ff       ..
     jsr osbyte                                                        ; 2dd3: 20 f4 ff     ..            ; Read character status flag ($e0-$ef)
@@ -3932,13 +3932,13 @@ buffer_empty
     sty mem                                                           ; 2dd8: 84 70       .p             ; Y=value of character status flag ($f0-$ff)
 
     ; *************** Test OSBYTE 0xe0 ***************
-    lda #osbyte_read_write_f0_ff_status                               ; 2dda: a9 e0       ..
+    lda #osbyte_read_write_characters_f0_ff_status                    ; 2dda: a9 e0       ..
     ldx #$2a ; '*'                                                    ; 2ddc: a2 2a       .*
     ldy #0                                                            ; 2dde: a0 00       ..
     jsr osbyte                                                        ; 2de0: 20 f4 ff     ..            ; Write character status flag ($f0-$ff), value X=42
     stx mem                                                           ; 2de3: 86 70       .p             ; X=old value of character status flag ($f0-$ff)
     sty mem                                                           ; 2de5: 84 70       .p             ; Y=value of function key status
-    lda #osbyte_read_write_f0_ff_status                               ; 2de7: a9 e0       ..
+    lda #osbyte_read_write_characters_f0_ff_status                    ; 2de7: a9 e0       ..
     ldx #0                                                            ; 2de9: a2 00       ..
     ldy #$ff                                                          ; 2deb: a0 ff       ..
     jsr osbyte                                                        ; 2ded: 20 f4 ff     ..            ; Read character status flag ($f0-$ff)
@@ -4016,13 +4016,13 @@ buffer_empty
     sty mem                                                           ; 2e74: 84 70       .p             ; Y=value of ESCAPE effects
 
     ; *************** Test OSBYTE 0xe6 ***************
-    lda #osbyte_read_write_escape_flags                               ; 2e76: a9 e6       ..
+    lda #osbyte_read_write_escape_effects                             ; 2e76: a9 e6       ..
     ldx #$2a ; '*'                                                    ; 2e78: a2 2a       .*
     ldy #0                                                            ; 2e7a: a0 00       ..
     jsr osbyte                                                        ; 2e7c: 20 f4 ff     ..            ; Write ESCAPE effects, value X=42
     stx mem                                                           ; 2e7f: 86 70       .p             ; X=old value of ESCAPE effects
     sty mem                                                           ; 2e81: 84 70       .p             ; Y=value of User 6522 IRQ bit mask
-    lda #osbyte_read_write_escape_flags                               ; 2e83: a9 e6       ..
+    lda #osbyte_read_write_escape_effects                             ; 2e83: a9 e6       ..
     ldx #0                                                            ; 2e85: a2 00       ..
     ldy #$ff                                                          ; 2e87: a0 ff       ..
     jsr osbyte                                                        ; 2e89: 20 f4 ff     ..            ; Read ESCAPE effects
@@ -4226,13 +4226,13 @@ buffer_empty
     sty mem                                                           ; 2ffa: 84 70       .p             ; Y=value of printer destination
 
     ; *************** Test OSBYTE 0xf5 ***************
-    lda #osbyte_read_write_printer_destination_flag                   ; 2ffc: a9 f5       ..
+    lda #osbyte_read_write_printer_destination                        ; 2ffc: a9 f5       ..
     ldx #$2a ; '*'                                                    ; 2ffe: a2 2a       .*
     ldy #0                                                            ; 3000: a0 00       ..
     jsr osbyte                                                        ; 3002: 20 f4 ff     ..            ; Write printer destination, value X=42
     stx mem                                                           ; 3005: 86 70       .p             ; X=old value of printer destination
     sty mem                                                           ; 3007: 84 70       .p             ; Y=value of printer ignore character
-    lda #osbyte_read_write_printer_destination_flag                   ; 3009: a9 f5       ..
+    lda #osbyte_read_write_printer_destination                        ; 3009: a9 f5       ..
     ldx #0                                                            ; 300b: a2 00       ..
     ldy #$ff                                                          ; 300d: a0 ff       ..
     jsr osbyte                                                        ; 300f: 20 f4 ff     ..            ; Read printer destination
@@ -4367,7 +4367,7 @@ buffer_empty
 
     ; *************** Test OSBYTE 0xff ***************
     lda #osbyte_read_write_startup_options                            ; 3100: a9 ff       ..
-    ldx #$2a ; '*'                                                    ; 3102: a2 2a       .*
+    ldx #%00101010                                                    ; 3102: a2 2a       .*
     ldy #0                                                            ; 3104: a0 00       ..
     jsr osbyte                                                        ; 3106: 20 f4 ff     ..            ; Write start-up option byte, value X=42
 
@@ -6241,8 +6241,8 @@ pydis_end
 !if (osbyte_read_rom_ptr_table_low) != $a8 {
     !error "Assertion failed: osbyte_read_rom_ptr_table_low == $a8"
 }
-!if (osbyte_read_serial_control_flag) != $c0 {
-    !error "Assertion failed: osbyte_read_serial_control_flag == $c0"
+!if (osbyte_read_serial_control_register_copy) != $c0 {
+    !error "Assertion failed: osbyte_read_serial_control_register_copy == $c0"
 }
 !if (osbyte_read_serial_ula) != $f2 {
     !error "Assertion failed: osbyte_read_serial_ula == $f2"
@@ -6325,9 +6325,6 @@ pydis_end
 !if (osbyte_read_write_bell_frequency) != $d5 {
     !error "Assertion failed: osbyte_read_write_bell_frequency == $d5"
 }
-!if (osbyte_read_write_c0_cf_status) != $dd {
-    !error "Assertion failed: osbyte_read_write_c0_cf_status == $dd"
-}
 !if (osbyte_read_write_cassette_serial_selection) != $cd {
     !error "Assertion failed: osbyte_read_write_cassette_serial_selection == $cd"
 }
@@ -6339,6 +6336,18 @@ pydis_end
 }
 !if (osbyte_read_write_char_destination_status) != $ec {
     !error "Assertion failed: osbyte_read_write_char_destination_status == $ec"
+}
+!if (osbyte_read_write_characters_c0_cf_status) != $dd {
+    !error "Assertion failed: osbyte_read_write_characters_c0_cf_status == $dd"
+}
+!if (osbyte_read_write_characters_d0_df_status) != $de {
+    !error "Assertion failed: osbyte_read_write_characters_d0_df_status == $de"
+}
+!if (osbyte_read_write_characters_e0_ef_status) != $df {
+    !error "Assertion failed: osbyte_read_write_characters_e0_ef_status == $df"
+}
+!if (osbyte_read_write_characters_f0_ff_status) != $e0 {
+    !error "Assertion failed: osbyte_read_write_characters_f0_ff_status == $e0"
 }
 !if (osbyte_read_write_ctrl_function_key_status) != $e3 {
     !error "Assertion failed: osbyte_read_write_ctrl_function_key_status == $e3"
@@ -6354,12 +6363,6 @@ pydis_end
 }
 !if (osbyte_read_write_cursor_editing_status) != $ed {
     !error "Assertion failed: osbyte_read_write_cursor_editing_status == $ed"
-}
-!if (osbyte_read_write_d0_df_status) != $de {
-    !error "Assertion failed: osbyte_read_write_d0_df_status == $de"
-}
-!if (osbyte_read_write_e0_ef_status) != $df {
-    !error "Assertion failed: osbyte_read_write_e0_ef_status == $df"
 }
 !if (osbyte_read_write_econet_keyboard_disable) != $c9 {
     !error "Assertion failed: osbyte_read_write_econet_keyboard_disable == $c9"
@@ -6379,17 +6382,14 @@ pydis_end
 !if (osbyte_read_write_escape_char) != $dc {
     !error "Assertion failed: osbyte_read_write_escape_char == $dc"
 }
-!if (osbyte_read_write_escape_flags) != $e6 {
-    !error "Assertion failed: osbyte_read_write_escape_flags == $e6"
+!if (osbyte_read_write_escape_effects) != $e6 {
+    !error "Assertion failed: osbyte_read_write_escape_effects == $e6"
 }
 !if (osbyte_read_write_escape_status) != $e5 {
     !error "Assertion failed: osbyte_read_write_escape_status == $e5"
 }
 !if (osbyte_read_write_exec_file_handle) != $c6 {
     !error "Assertion failed: osbyte_read_write_exec_file_handle == $c6"
-}
-!if (osbyte_read_write_f0_ff_status) != $e0 {
-    !error "Assertion failed: osbyte_read_write_f0_ff_status == $e0"
 }
 !if (osbyte_read_write_first_byte_break_intercept) != $f7 {
     !error "Assertion failed: osbyte_read_write_first_byte_break_intercept == $f7"
@@ -6430,8 +6430,8 @@ pydis_end
 !if (osbyte_read_write_primary_oshwm) != $b3 {
     !error "Assertion failed: osbyte_read_write_primary_oshwm == $b3"
 }
-!if (osbyte_read_write_printer_destination_flag) != $f5 {
-    !error "Assertion failed: osbyte_read_write_printer_destination_flag == $f5"
+!if (osbyte_read_write_printer_destination) != $f5 {
+    !error "Assertion failed: osbyte_read_write_printer_destination == $f5"
 }
 !if (osbyte_read_write_printer_ignore_char) != $f6 {
     !error "Assertion failed: osbyte_read_write_printer_ignore_char == $f6"

--- a/examples/known_good/acorn_os_calls_acme.asm
+++ b/examples/known_good/acorn_os_calls_acme.asm
@@ -4572,7 +4572,7 @@ buffer_empty
     ldy mem                                                           ; 3275: a4 70       .p             ; Y=file handle
     jsr osbget                                                        ; 3277: 20 d7 ff     ..            ; Read a single byte from an open file Y
     cmp #0                                                            ; 327a: c9 00       ..
-    jsr osnewl                                                        ; 327c: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; 327c: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     jsr oswrcr                                                        ; 327f: 20 ec ff     ..            ; Write carriage return (character 13)
     lda #$41 ; 'A'                                                    ; 3282: a9 41       .A
     jsr oswrch                                                        ; 3284: 20 ee ff     ..            ; Write character 65

--- a/examples/known_good/acorn_os_calls_beebasm.asm
+++ b/examples/known_good/acorn_os_calls_beebasm.asm
@@ -78,7 +78,7 @@ osbyte_read_rom_info_table_high                    = 171
 osbyte_read_rom_info_table_low                     = 170
 osbyte_read_rom_ptr_table_high                     = 169
 osbyte_read_rom_ptr_table_low                      = 168
-osbyte_read_serial_control_flag                    = 192
+osbyte_read_serial_control_register_copy           = 192
 osbyte_read_serial_ula                             = 242
 osbyte_read_sheila                                 = 150
 osbyte_read_speech                                 = 158
@@ -106,28 +106,28 @@ osbyte_read_write_bell_channel                     = 211
 osbyte_read_write_bell_duration                    = 214
 osbyte_read_write_bell_envelope                    = 212
 osbyte_read_write_bell_frequency                   = 213
-osbyte_read_write_c0_cf_status                     = 221
 osbyte_read_write_cassette_serial_selection        = 205
 osbyte_read_write_cfs_rfs_switch                   = 183
 osbyte_read_write_cfs_timeout                      = 176
 osbyte_read_write_char_destination_status          = 236
+osbyte_read_write_characters_c0_cf_status          = 221
+osbyte_read_write_characters_d0_df_status          = 222
+osbyte_read_write_characters_e0_ef_status          = 223
+osbyte_read_write_characters_f0_ff_status          = 224
 osbyte_read_write_ctrl_function_key_status         = 227
 osbyte_read_write_ctrl_shift_function_key_status   = 228
 osbyte_read_write_current_language_rom_bank        = 252
 osbyte_read_write_current_oshwm                    = 180
 osbyte_read_write_cursor_editing_status            = 237
-osbyte_read_write_d0_df_status                     = 222
-osbyte_read_write_e0_ef_status                     = 223
 osbyte_read_write_econet_keyboard_disable          = 201
 osbyte_read_write_econet_os_call_interception      = 206
 osbyte_read_write_econet_osrdch_interception       = 207
 osbyte_read_write_econet_oswrch_interception       = 208
 osbyte_read_write_escape_break_effect              = 200
 osbyte_read_write_escape_char                      = 220
-osbyte_read_write_escape_flags                     = 230
+osbyte_read_write_escape_effects                   = 230
 osbyte_read_write_escape_status                    = 229
 osbyte_read_write_exec_file_handle                 = 198
-osbyte_read_write_f0_ff_status                     = 224
 osbyte_read_write_first_byte_break_intercept       = 247
 osbyte_read_write_flash_counter                    = 193
 osbyte_read_write_function_key_status              = 225
@@ -141,7 +141,7 @@ osbyte_read_write_lines_since_last_page            = 217
 osbyte_read_write_mark_count                       = 194
 osbyte_read_write_max_adc_channel                  = 189
 osbyte_read_write_primary_oshwm                    = 179
-osbyte_read_write_printer_destination_flag         = 245
+osbyte_read_write_printer_destination              = 245
 osbyte_read_write_printer_ignore_char              = 246
 osbyte_read_write_rom_bank_at_last_brk             = 186
 osbyte_read_write_second_byte_break_intercept      = 248
@@ -3484,13 +3484,13 @@ osbyte  = &fff4
     sty mem                                                           ; 2a98: 84 70       .p             ; Y=value of OS copy of 6850 (ACIA) control register
 
     ; *************** Test OSBYTE 0xc0 ***************
-    lda #osbyte_read_serial_control_flag                              ; 2a9a: a9 c0       ..
+    lda #osbyte_read_serial_control_register_copy                     ; 2a9a: a9 c0       ..
     ldx #&2a ; '*'                                                    ; 2a9c: a2 2a       .*
     ldy #0                                                            ; 2a9e: a0 00       ..
     jsr osbyte                                                        ; 2aa0: 20 f4 ff     ..            ; Write OS copy of 6850 (ACIA) control register, value X=42
     stx mem                                                           ; 2aa3: 86 70       .p             ; X=old value of OS copy of 6850 (ACIA) control register
     sty mem                                                           ; 2aa5: 84 70       .p             ; Y=value of flash counter in fiftieths of a second
-    lda #osbyte_read_serial_control_flag                              ; 2aa7: a9 c0       ..
+    lda #osbyte_read_serial_control_register_copy                     ; 2aa7: a9 c0       ..
     ldx #0                                                            ; 2aa9: a2 00       ..
     ldy #&ff                                                          ; 2aab: a0 ff       ..
     jsr osbyte                                                        ; 2aad: 20 f4 ff     ..            ; Read OS copy of 6850 (ACIA) control register
@@ -3890,13 +3890,13 @@ osbyte  = &fff4
     sty mem                                                           ; 2d8a: 84 70       .p             ; Y=value of character status flag ($c0-$cf)
 
     ; *************** Test OSBYTE 0xdd ***************
-    lda #osbyte_read_write_c0_cf_status                               ; 2d8c: a9 dd       ..
+    lda #osbyte_read_write_characters_c0_cf_status                    ; 2d8c: a9 dd       ..
     ldx #&2a ; '*'                                                    ; 2d8e: a2 2a       .*
     ldy #0                                                            ; 2d90: a0 00       ..
     jsr osbyte                                                        ; 2d92: 20 f4 ff     ..            ; Write character status flag ($c0-$cf), value X=42
     stx mem                                                           ; 2d95: 86 70       .p             ; X=old value of character status flag ($c0-$cf)
     sty mem                                                           ; 2d97: 84 70       .p             ; Y=value of character status flag ($d0-$df)
-    lda #osbyte_read_write_c0_cf_status                               ; 2d99: a9 dd       ..
+    lda #osbyte_read_write_characters_c0_cf_status                    ; 2d99: a9 dd       ..
     ldx #0                                                            ; 2d9b: a2 00       ..
     ldy #&ff                                                          ; 2d9d: a0 ff       ..
     jsr osbyte                                                        ; 2d9f: 20 f4 ff     ..            ; Read character status flag ($c0-$cf)
@@ -3904,13 +3904,13 @@ osbyte  = &fff4
     sty mem                                                           ; 2da4: 84 70       .p             ; Y=value of character status flag ($d0-$df)
 
     ; *************** Test OSBYTE 0xde ***************
-    lda #osbyte_read_write_d0_df_status                               ; 2da6: a9 de       ..
+    lda #osbyte_read_write_characters_d0_df_status                    ; 2da6: a9 de       ..
     ldx #&2a ; '*'                                                    ; 2da8: a2 2a       .*
     ldy #0                                                            ; 2daa: a0 00       ..
     jsr osbyte                                                        ; 2dac: 20 f4 ff     ..            ; Write character status flag ($d0-$df), value X=42
     stx mem                                                           ; 2daf: 86 70       .p             ; X=old value of character status flag ($d0-$df)
     sty mem                                                           ; 2db1: 84 70       .p             ; Y=value of character status flag ($e0-$ef)
-    lda #osbyte_read_write_d0_df_status                               ; 2db3: a9 de       ..
+    lda #osbyte_read_write_characters_d0_df_status                    ; 2db3: a9 de       ..
     ldx #0                                                            ; 2db5: a2 00       ..
     ldy #&ff                                                          ; 2db7: a0 ff       ..
     jsr osbyte                                                        ; 2db9: 20 f4 ff     ..            ; Read character status flag ($d0-$df)
@@ -3918,13 +3918,13 @@ osbyte  = &fff4
     sty mem                                                           ; 2dbe: 84 70       .p             ; Y=value of character status flag ($e0-$ef)
 
     ; *************** Test OSBYTE 0xdf ***************
-    lda #osbyte_read_write_e0_ef_status                               ; 2dc0: a9 df       ..
+    lda #osbyte_read_write_characters_e0_ef_status                    ; 2dc0: a9 df       ..
     ldx #&2a ; '*'                                                    ; 2dc2: a2 2a       .*
     ldy #0                                                            ; 2dc4: a0 00       ..
     jsr osbyte                                                        ; 2dc6: 20 f4 ff     ..            ; Write character status flag ($e0-$ef), value X=42
     stx mem                                                           ; 2dc9: 86 70       .p             ; X=old value of character status flag ($e0-$ef)
     sty mem                                                           ; 2dcb: 84 70       .p             ; Y=value of character status flag ($f0-$ff)
-    lda #osbyte_read_write_e0_ef_status                               ; 2dcd: a9 df       ..
+    lda #osbyte_read_write_characters_e0_ef_status                    ; 2dcd: a9 df       ..
     ldx #0                                                            ; 2dcf: a2 00       ..
     ldy #&ff                                                          ; 2dd1: a0 ff       ..
     jsr osbyte                                                        ; 2dd3: 20 f4 ff     ..            ; Read character status flag ($e0-$ef)
@@ -3932,13 +3932,13 @@ osbyte  = &fff4
     sty mem                                                           ; 2dd8: 84 70       .p             ; Y=value of character status flag ($f0-$ff)
 
     ; *************** Test OSBYTE 0xe0 ***************
-    lda #osbyte_read_write_f0_ff_status                               ; 2dda: a9 e0       ..
+    lda #osbyte_read_write_characters_f0_ff_status                    ; 2dda: a9 e0       ..
     ldx #&2a ; '*'                                                    ; 2ddc: a2 2a       .*
     ldy #0                                                            ; 2dde: a0 00       ..
     jsr osbyte                                                        ; 2de0: 20 f4 ff     ..            ; Write character status flag ($f0-$ff), value X=42
     stx mem                                                           ; 2de3: 86 70       .p             ; X=old value of character status flag ($f0-$ff)
     sty mem                                                           ; 2de5: 84 70       .p             ; Y=value of function key status
-    lda #osbyte_read_write_f0_ff_status                               ; 2de7: a9 e0       ..
+    lda #osbyte_read_write_characters_f0_ff_status                    ; 2de7: a9 e0       ..
     ldx #0                                                            ; 2de9: a2 00       ..
     ldy #&ff                                                          ; 2deb: a0 ff       ..
     jsr osbyte                                                        ; 2ded: 20 f4 ff     ..            ; Read character status flag ($f0-$ff)
@@ -4016,13 +4016,13 @@ osbyte  = &fff4
     sty mem                                                           ; 2e74: 84 70       .p             ; Y=value of ESCAPE effects
 
     ; *************** Test OSBYTE 0xe6 ***************
-    lda #osbyte_read_write_escape_flags                               ; 2e76: a9 e6       ..
+    lda #osbyte_read_write_escape_effects                             ; 2e76: a9 e6       ..
     ldx #&2a ; '*'                                                    ; 2e78: a2 2a       .*
     ldy #0                                                            ; 2e7a: a0 00       ..
     jsr osbyte                                                        ; 2e7c: 20 f4 ff     ..            ; Write ESCAPE effects, value X=42
     stx mem                                                           ; 2e7f: 86 70       .p             ; X=old value of ESCAPE effects
     sty mem                                                           ; 2e81: 84 70       .p             ; Y=value of User 6522 IRQ bit mask
-    lda #osbyte_read_write_escape_flags                               ; 2e83: a9 e6       ..
+    lda #osbyte_read_write_escape_effects                             ; 2e83: a9 e6       ..
     ldx #0                                                            ; 2e85: a2 00       ..
     ldy #&ff                                                          ; 2e87: a0 ff       ..
     jsr osbyte                                                        ; 2e89: 20 f4 ff     ..            ; Read ESCAPE effects
@@ -4226,13 +4226,13 @@ osbyte  = &fff4
     sty mem                                                           ; 2ffa: 84 70       .p             ; Y=value of printer destination
 
     ; *************** Test OSBYTE 0xf5 ***************
-    lda #osbyte_read_write_printer_destination_flag                   ; 2ffc: a9 f5       ..
+    lda #osbyte_read_write_printer_destination                        ; 2ffc: a9 f5       ..
     ldx #&2a ; '*'                                                    ; 2ffe: a2 2a       .*
     ldy #0                                                            ; 3000: a0 00       ..
     jsr osbyte                                                        ; 3002: 20 f4 ff     ..            ; Write printer destination, value X=42
     stx mem                                                           ; 3005: 86 70       .p             ; X=old value of printer destination
     sty mem                                                           ; 3007: 84 70       .p             ; Y=value of printer ignore character
-    lda #osbyte_read_write_printer_destination_flag                   ; 3009: a9 f5       ..
+    lda #osbyte_read_write_printer_destination                        ; 3009: a9 f5       ..
     ldx #0                                                            ; 300b: a2 00       ..
     ldy #&ff                                                          ; 300d: a0 ff       ..
     jsr osbyte                                                        ; 300f: 20 f4 ff     ..            ; Read printer destination
@@ -4367,7 +4367,7 @@ osbyte  = &fff4
 
     ; *************** Test OSBYTE 0xff ***************
     lda #osbyte_read_write_startup_options                            ; 3100: a9 ff       ..
-    ldx #&2a ; '*'                                                    ; 3102: a2 2a       .*
+    ldx #%00101010                                                    ; 3102: a2 2a       .*
     ldy #0                                                            ; 3104: a0 00       ..
     jsr osbyte                                                        ; 3106: 20 f4 ff     ..            ; Write start-up option byte, value X=42
 
@@ -5991,7 +5991,7 @@ osbyte  = &fff4
     assert osbyte_read_rom_info_table_low == &aa
     assert osbyte_read_rom_ptr_table_high == &a9
     assert osbyte_read_rom_ptr_table_low == &a8
-    assert osbyte_read_serial_control_flag == &c0
+    assert osbyte_read_serial_control_register_copy == &c0
     assert osbyte_read_serial_ula == &f2
     assert osbyte_read_sheila == &96
     assert osbyte_read_speech == &9e
@@ -6019,28 +6019,28 @@ osbyte  = &fff4
     assert osbyte_read_write_bell_duration == &d6
     assert osbyte_read_write_bell_envelope == &d4
     assert osbyte_read_write_bell_frequency == &d5
-    assert osbyte_read_write_c0_cf_status == &dd
     assert osbyte_read_write_cassette_serial_selection == &cd
     assert osbyte_read_write_cfs_rfs_switch == &b7
     assert osbyte_read_write_cfs_timeout == &b0
     assert osbyte_read_write_char_destination_status == &ec
+    assert osbyte_read_write_characters_c0_cf_status == &dd
+    assert osbyte_read_write_characters_d0_df_status == &de
+    assert osbyte_read_write_characters_e0_ef_status == &df
+    assert osbyte_read_write_characters_f0_ff_status == &e0
     assert osbyte_read_write_ctrl_function_key_status == &e3
     assert osbyte_read_write_ctrl_shift_function_key_status == &e4
     assert osbyte_read_write_current_language_rom_bank == &fc
     assert osbyte_read_write_current_oshwm == &b4
     assert osbyte_read_write_cursor_editing_status == &ed
-    assert osbyte_read_write_d0_df_status == &de
-    assert osbyte_read_write_e0_ef_status == &df
     assert osbyte_read_write_econet_keyboard_disable == &c9
     assert osbyte_read_write_econet_os_call_interception == &ce
     assert osbyte_read_write_econet_osrdch_interception == &cf
     assert osbyte_read_write_econet_oswrch_interception == &d0
     assert osbyte_read_write_escape_break_effect == &c8
     assert osbyte_read_write_escape_char == &dc
-    assert osbyte_read_write_escape_flags == &e6
+    assert osbyte_read_write_escape_effects == &e6
     assert osbyte_read_write_escape_status == &e5
     assert osbyte_read_write_exec_file_handle == &c6
-    assert osbyte_read_write_f0_ff_status == &e0
     assert osbyte_read_write_first_byte_break_intercept == &f7
     assert osbyte_read_write_flash_counter == &c1
     assert osbyte_read_write_function_key_status == &e1
@@ -6054,7 +6054,7 @@ osbyte  = &fff4
     assert osbyte_read_write_mark_count == &c2
     assert osbyte_read_write_max_adc_channel == &bd
     assert osbyte_read_write_primary_oshwm == &b3
-    assert osbyte_read_write_printer_destination_flag == &f5
+    assert osbyte_read_write_printer_destination == &f5
     assert osbyte_read_write_printer_ignore_char == &f6
     assert osbyte_read_write_rom_bank_at_last_brk == &ba
     assert osbyte_read_write_second_byte_break_intercept == &f8

--- a/examples/known_good/acorn_os_calls_beebasm.asm
+++ b/examples/known_good/acorn_os_calls_beebasm.asm
@@ -4572,7 +4572,7 @@ osbyte  = &fff4
     ldy mem                                                           ; 3275: a4 70       .p             ; Y=file handle
     jsr osbget                                                        ; 3277: 20 d7 ff     ..            ; Read a single byte from an open file Y
     cmp #0                                                            ; 327a: c9 00       ..
-    jsr osnewl                                                        ; 327c: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; 327c: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     jsr oswrcr                                                        ; 327f: 20 ec ff     ..            ; Write carriage return (character 13)
     lda #&41 ; 'A'                                                    ; 3282: a9 41       .A
     jsr oswrch                                                        ; 3284: 20 ee ff     ..            ; Write character 65

--- a/examples/known_good/acorn_os_calls_beebasm.asm
+++ b/examples/known_good/acorn_os_calls_beebasm.asm
@@ -1,4 +1,34 @@
 ; Constants
+baud_rate_1200                                     = 4
+baud_rate_150                                      = 2
+baud_rate_19200                                    = 8
+baud_rate_2400                                     = 5
+baud_rate_300                                      = 3
+baud_rate_4800                                     = 6
+baud_rate_75                                       = 1
+baud_rate_9600                                     = 7
+baud_rate_default_9600                             = 0
+buffer_keyboard                                    = 0
+buffer_printer                                     = 3
+buffer_rs423_input                                 = 1
+buffer_rs423_output                                = 2
+buffer_sound_channel_0                             = 4
+buffer_sound_channel_1                             = 5
+buffer_sound_channel_2                             = 6
+buffer_sound_channel_3                             = 7
+buffer_speech                                      = 8
+event_adc_conversion_complete                      = 3
+event_character_entering_input_buffer              = 2
+event_escape_condition_detected                    = 6
+event_input_buffer_full                            = 1
+event_interval_timer_crossing_zero                 = 5
+event_network_error                                = 8
+event_output_buffer_empty                          = 0
+event_rs423_error                                  = 7
+event_start_of_vertical_sync                       = 4
+event_user                                         = 9
+inkey_key_ctrl                                     = 254
+inkey_key_f0                                       = 223
 inkey_key_shift                                    = 255
 osbyte_acknowledge_escape                          = 126
 osbyte_check_eof                                   = 127
@@ -177,6 +207,10 @@ osfile_write_attributes                            = 4
 osfile_write_catalogue_info                        = 1
 osfile_write_exec_addr                             = 3
 osfile_write_load_addr                             = 2
+osfind_close                                       = 0
+osfind_open_input                                  = 64
+osfind_open_output                                 = 128
+osfind_open_random_access                          = 192
 osgbpb_append_bytes                                = 2
 osgbpb_read_bytes_from_current_position            = 4
 osgbpb_read_bytes_from_position                    = 3
@@ -311,19 +345,19 @@ osbyte  = &fff4
     lda #osbyte_set_cursor_editing                                    ; 118f: a9 04       ..
     ldx #0                                                            ; 1191: a2 00       ..
     ldy #0                                                            ; 1193: a0 00       ..
-    jsr osbyte                                                        ; 1195: 20 f4 ff     ..            ; Enable cursor editing
+    jsr osbyte                                                        ; 1195: 20 f4 ff     ..            ; Enable cursor editing (X=0)
     lda #osbyte_set_cursor_editing                                    ; 1198: a9 04       ..
     ldx #1                                                            ; 119a: a2 01       ..
     ldy #0                                                            ; 119c: a0 00       ..
-    jsr osbyte                                                        ; 119e: 20 f4 ff     ..            ; Disable cursor editing (edit keys give ASCII 135-139)
+    jsr osbyte                                                        ; 119e: 20 f4 ff     ..            ; Disable cursor editing (edit keys give ASCII 135-139) (X=1)
     lda #osbyte_set_cursor_editing                                    ; 11a1: a9 04       ..
     ldx #2                                                            ; 11a3: a2 02       ..
     ldy #0                                                            ; 11a5: a0 00       ..
-    jsr osbyte                                                        ; 11a7: 20 f4 ff     ..            ; Disable cursor editing (edit keys act as soft keys f11 to f15)
+    jsr osbyte                                                        ; 11a7: 20 f4 ff     ..            ; Disable cursor editing (edit keys act as soft keys f11 to f15) (X=2)
     lda #osbyte_set_cursor_editing                                    ; 11aa: a9 04       ..
     ldx #3                                                            ; 11ac: a2 03       ..
     ldy #0                                                            ; 11ae: a0 00       ..
-    jsr osbyte                                                        ; 11b0: 20 f4 ff     ..            ; Cursor editing keys and COPY simulate a joystick (Master Compact only)
+    jsr osbyte                                                        ; 11b0: 20 f4 ff     ..            ; Cursor editing keys and COPY simulate a joystick (Master Compact only) (X=3)
     lda #osbyte_set_cursor_editing                                    ; 11b3: a9 04       ..
     ldx #4                                                            ; 11b5: a2 04       ..
     ldy #0                                                            ; 11b7: a0 00       ..
@@ -392,39 +426,39 @@ osbyte  = &fff4
     ldy #0                                                            ; 1217: a0 00       ..
     jsr osbyte                                                        ; 1219: 20 f4 ff     ..            ; Set serial receive rate based on X
     lda #osbyte_set_serial_receive_rate                               ; 121c: a9 07       ..
-    ldx #0                                                            ; 121e: a2 00       ..
+    ldx #baud_rate_default_9600                                       ; 121e: a2 00       ..
     ldy #0                                                            ; 1220: a0 00       ..
-    jsr osbyte                                                        ; 1222: 20 f4 ff     ..            ; Set serial receive rate to 9600 baud (X=0)
+    jsr osbyte                                                        ; 1222: 20 f4 ff     ..            ; Set serial receive rate to default 9600 baud (X=0)
     lda #osbyte_set_serial_receive_rate                               ; 1225: a9 07       ..
-    ldx #1                                                            ; 1227: a2 01       ..
+    ldx #baud_rate_75                                                 ; 1227: a2 01       ..
     ldy #0                                                            ; 1229: a0 00       ..
     jsr osbyte                                                        ; 122b: 20 f4 ff     ..            ; Set serial receive rate to 75 baud (X=1)
     lda #osbyte_set_serial_receive_rate                               ; 122e: a9 07       ..
-    ldx #2                                                            ; 1230: a2 02       ..
+    ldx #baud_rate_150                                                ; 1230: a2 02       ..
     ldy #0                                                            ; 1232: a0 00       ..
     jsr osbyte                                                        ; 1234: 20 f4 ff     ..            ; Set serial receive rate to 150 baud (X=2)
     lda #osbyte_set_serial_receive_rate                               ; 1237: a9 07       ..
-    ldx #3                                                            ; 1239: a2 03       ..
+    ldx #baud_rate_300                                                ; 1239: a2 03       ..
     ldy #0                                                            ; 123b: a0 00       ..
     jsr osbyte                                                        ; 123d: 20 f4 ff     ..            ; Set serial receive rate to 300 baud (X=3)
     lda #osbyte_set_serial_receive_rate                               ; 1240: a9 07       ..
-    ldx #4                                                            ; 1242: a2 04       ..
+    ldx #baud_rate_1200                                               ; 1242: a2 04       ..
     ldy #0                                                            ; 1244: a0 00       ..
     jsr osbyte                                                        ; 1246: 20 f4 ff     ..            ; Set serial receive rate to 1200 baud (X=4)
     lda #osbyte_set_serial_receive_rate                               ; 1249: a9 07       ..
-    ldx #5                                                            ; 124b: a2 05       ..
+    ldx #baud_rate_2400                                               ; 124b: a2 05       ..
     ldy #0                                                            ; 124d: a0 00       ..
     jsr osbyte                                                        ; 124f: 20 f4 ff     ..            ; Set serial receive rate to 2400 baud (X=5)
     lda #osbyte_set_serial_receive_rate                               ; 1252: a9 07       ..
-    ldx #6                                                            ; 1254: a2 06       ..
+    ldx #baud_rate_4800                                               ; 1254: a2 06       ..
     ldy #0                                                            ; 1256: a0 00       ..
     jsr osbyte                                                        ; 1258: 20 f4 ff     ..            ; Set serial receive rate to 4800 baud (X=6)
     lda #osbyte_set_serial_receive_rate                               ; 125b: a9 07       ..
-    ldx #7                                                            ; 125d: a2 07       ..
+    ldx #baud_rate_9600                                               ; 125d: a2 07       ..
     ldy #0                                                            ; 125f: a0 00       ..
     jsr osbyte                                                        ; 1261: 20 f4 ff     ..            ; Set serial receive rate to 9600 baud (X=7)
     lda #osbyte_set_serial_receive_rate                               ; 1264: a9 07       ..
-    ldx #8                                                            ; 1266: a2 08       ..
+    ldx #baud_rate_19200                                              ; 1266: a2 08       ..
     ldy #0                                                            ; 1268: a0 00       ..
     jsr osbyte                                                        ; 126a: 20 f4 ff     ..            ; Set serial receive rate to 19200 baud (X=8)
     lda #osbyte_set_serial_receive_rate                               ; 126d: a9 07       ..
@@ -446,39 +480,39 @@ osbyte  = &fff4
     ldy #0                                                            ; 127e: a0 00       ..
     jsr osbyte                                                        ; 1280: 20 f4 ff     ..            ; Set serial transmission rate based on X
     lda #osbyte_set_serial_transmit_rate                              ; 1283: a9 08       ..
-    ldx #0                                                            ; 1285: a2 00       ..
+    ldx #baud_rate_default_9600                                       ; 1285: a2 00       ..
     ldy #0                                                            ; 1287: a0 00       ..
-    jsr osbyte                                                        ; 1289: 20 f4 ff     ..            ; Set serial transmission rate to 9600 baud (X=0)
+    jsr osbyte                                                        ; 1289: 20 f4 ff     ..            ; Set serial transmission rate to default 9600 baud (X=0)
     lda #osbyte_set_serial_transmit_rate                              ; 128c: a9 08       ..
-    ldx #1                                                            ; 128e: a2 01       ..
+    ldx #baud_rate_75                                                 ; 128e: a2 01       ..
     ldy #0                                                            ; 1290: a0 00       ..
     jsr osbyte                                                        ; 1292: 20 f4 ff     ..            ; Set serial transmission rate to 75 baud (X=1)
     lda #osbyte_set_serial_transmit_rate                              ; 1295: a9 08       ..
-    ldx #2                                                            ; 1297: a2 02       ..
+    ldx #baud_rate_150                                                ; 1297: a2 02       ..
     ldy #0                                                            ; 1299: a0 00       ..
     jsr osbyte                                                        ; 129b: 20 f4 ff     ..            ; Set serial transmission rate to 150 baud (X=2)
     lda #osbyte_set_serial_transmit_rate                              ; 129e: a9 08       ..
-    ldx #3                                                            ; 12a0: a2 03       ..
+    ldx #baud_rate_300                                                ; 12a0: a2 03       ..
     ldy #0                                                            ; 12a2: a0 00       ..
     jsr osbyte                                                        ; 12a4: 20 f4 ff     ..            ; Set serial transmission rate to 300 baud (X=3)
     lda #osbyte_set_serial_transmit_rate                              ; 12a7: a9 08       ..
-    ldx #4                                                            ; 12a9: a2 04       ..
+    ldx #baud_rate_1200                                               ; 12a9: a2 04       ..
     ldy #0                                                            ; 12ab: a0 00       ..
     jsr osbyte                                                        ; 12ad: 20 f4 ff     ..            ; Set serial transmission rate to 1200 baud (X=4)
     lda #osbyte_set_serial_transmit_rate                              ; 12b0: a9 08       ..
-    ldx #5                                                            ; 12b2: a2 05       ..
+    ldx #baud_rate_2400                                               ; 12b2: a2 05       ..
     ldy #0                                                            ; 12b4: a0 00       ..
     jsr osbyte                                                        ; 12b6: 20 f4 ff     ..            ; Set serial transmission rate to 2400 baud (X=5)
     lda #osbyte_set_serial_transmit_rate                              ; 12b9: a9 08       ..
-    ldx #6                                                            ; 12bb: a2 06       ..
+    ldx #baud_rate_4800                                               ; 12bb: a2 06       ..
     ldy #0                                                            ; 12bd: a0 00       ..
     jsr osbyte                                                        ; 12bf: 20 f4 ff     ..            ; Set serial transmission rate to 4800 baud (X=6)
     lda #osbyte_set_serial_transmit_rate                              ; 12c2: a9 08       ..
-    ldx #7                                                            ; 12c4: a2 07       ..
+    ldx #baud_rate_9600                                               ; 12c4: a2 07       ..
     ldy #0                                                            ; 12c6: a0 00       ..
     jsr osbyte                                                        ; 12c8: 20 f4 ff     ..            ; Set serial transmission rate to 9600 baud (X=7)
     lda #osbyte_set_serial_transmit_rate                              ; 12cb: a9 08       ..
-    ldx #8                                                            ; 12cd: a2 08       ..
+    ldx #baud_rate_19200                                              ; 12cd: a2 08       ..
     ldy #0                                                            ; 12cf: a0 00       ..
     jsr osbyte                                                        ; 12d1: 20 f4 ff     ..            ; Set serial transmission rate to 19200 baud (X=8)
     lda #osbyte_set_serial_transmit_rate                              ; 12d4: a9 08       ..
@@ -571,43 +605,43 @@ osbyte  = &fff4
 
     ; *************** Test OSBYTE 0x0d ***************
     lda #osbyte_disable_event                                         ; 1377: a9 0d       ..
-    ldx #0                                                            ; 1379: a2 00       ..
+    ldx #event_output_buffer_empty                                    ; 1379: a2 00       ..
     ldy #0                                                            ; 137b: a0 00       ..
     jsr osbyte                                                        ; 137d: 20 f4 ff     ..            ; Disable 'Output buffer empty' event (X=0)
     lda #osbyte_disable_event                                         ; 1380: a9 0d       ..
-    ldx #1                                                            ; 1382: a2 01       ..
+    ldx #event_input_buffer_full                                      ; 1382: a2 01       ..
     ldy #0                                                            ; 1384: a0 00       ..
     jsr osbyte                                                        ; 1386: 20 f4 ff     ..            ; Disable 'Input buffer full' event (X=1)
     lda #osbyte_disable_event                                         ; 1389: a9 0d       ..
-    ldx #2                                                            ; 138b: a2 02       ..
+    ldx #event_character_entering_input_buffer                        ; 138b: a2 02       ..
     ldy #0                                                            ; 138d: a0 00       ..
     jsr osbyte                                                        ; 138f: 20 f4 ff     ..            ; Disable 'Character entering input buffer' event (X=2)
     lda #osbyte_disable_event                                         ; 1392: a9 0d       ..
-    ldx #3                                                            ; 1394: a2 03       ..
+    ldx #event_adc_conversion_complete                                ; 1394: a2 03       ..
     ldy #0                                                            ; 1396: a0 00       ..
     jsr osbyte                                                        ; 1398: 20 f4 ff     ..            ; Disable 'ADC conversion complete' event (X=3)
     lda #osbyte_disable_event                                         ; 139b: a9 0d       ..
-    ldx #4                                                            ; 139d: a2 04       ..
+    ldx #event_start_of_vertical_sync                                 ; 139d: a2 04       ..
     ldy #0                                                            ; 139f: a0 00       ..
     jsr osbyte                                                        ; 13a1: 20 f4 ff     ..            ; Disable 'Start of vertical sync' event (X=4)
     lda #osbyte_disable_event                                         ; 13a4: a9 0d       ..
-    ldx #5                                                            ; 13a6: a2 05       ..
+    ldx #event_interval_timer_crossing_zero                           ; 13a6: a2 05       ..
     ldy #0                                                            ; 13a8: a0 00       ..
     jsr osbyte                                                        ; 13aa: 20 f4 ff     ..            ; Disable 'Interval timer crossing zero' event (X=5)
     lda #osbyte_disable_event                                         ; 13ad: a9 0d       ..
-    ldx #6                                                            ; 13af: a2 06       ..
+    ldx #event_escape_condition_detected                              ; 13af: a2 06       ..
     ldy #0                                                            ; 13b1: a0 00       ..
     jsr osbyte                                                        ; 13b3: 20 f4 ff     ..            ; Disable 'ESCAPE condition detected' event (X=6)
     lda #osbyte_disable_event                                         ; 13b6: a9 0d       ..
-    ldx #7                                                            ; 13b8: a2 07       ..
+    ldx #event_rs423_error                                            ; 13b8: a2 07       ..
     ldy #0                                                            ; 13ba: a0 00       ..
     jsr osbyte                                                        ; 13bc: 20 f4 ff     ..            ; Disable 'RS423 error' event (X=7)
     lda #osbyte_disable_event                                         ; 13bf: a9 0d       ..
-    ldx #8                                                            ; 13c1: a2 08       ..
+    ldx #event_network_error                                          ; 13c1: a2 08       ..
     ldy #0                                                            ; 13c3: a0 00       ..
     jsr osbyte                                                        ; 13c5: 20 f4 ff     ..            ; Disable 'Network error' event (X=8)
     lda #osbyte_disable_event                                         ; 13c8: a9 0d       ..
-    ldx #9                                                            ; 13ca: a2 09       ..
+    ldx #event_user                                                   ; 13ca: a2 09       ..
     ldy #0                                                            ; 13cc: a0 00       ..
     jsr osbyte                                                        ; 13ce: 20 f4 ff     ..            ; Disable 'User' event (X=9)
     lda #osbyte_disable_event                                         ; 13d1: a9 0d       ..
@@ -618,43 +652,43 @@ osbyte  = &fff4
 
     ; *************** Test OSBYTE 0x0e ***************
     lda #osbyte_enable_event                                          ; 13dc: a9 0e       ..
-    ldx #0                                                            ; 13de: a2 00       ..
+    ldx #event_output_buffer_empty                                    ; 13de: a2 00       ..
     ldy #0                                                            ; 13e0: a0 00       ..
     jsr osbyte                                                        ; 13e2: 20 f4 ff     ..            ; Enable 'Output buffer empty' event (X=0)
     lda #osbyte_enable_event                                          ; 13e5: a9 0e       ..
-    ldx #1                                                            ; 13e7: a2 01       ..
+    ldx #event_input_buffer_full                                      ; 13e7: a2 01       ..
     ldy #0                                                            ; 13e9: a0 00       ..
     jsr osbyte                                                        ; 13eb: 20 f4 ff     ..            ; Enable 'Input buffer full' event (X=1)
     lda #osbyte_enable_event                                          ; 13ee: a9 0e       ..
-    ldx #2                                                            ; 13f0: a2 02       ..
+    ldx #event_character_entering_input_buffer                        ; 13f0: a2 02       ..
     ldy #0                                                            ; 13f2: a0 00       ..
     jsr osbyte                                                        ; 13f4: 20 f4 ff     ..            ; Enable 'Character entering input buffer' event (X=2)
     lda #osbyte_enable_event                                          ; 13f7: a9 0e       ..
-    ldx #3                                                            ; 13f9: a2 03       ..
+    ldx #event_adc_conversion_complete                                ; 13f9: a2 03       ..
     ldy #0                                                            ; 13fb: a0 00       ..
     jsr osbyte                                                        ; 13fd: 20 f4 ff     ..            ; Enable 'ADC conversion complete' event (X=3)
     lda #osbyte_enable_event                                          ; 1400: a9 0e       ..
-    ldx #4                                                            ; 1402: a2 04       ..
+    ldx #event_start_of_vertical_sync                                 ; 1402: a2 04       ..
     ldy #0                                                            ; 1404: a0 00       ..
     jsr osbyte                                                        ; 1406: 20 f4 ff     ..            ; Enable 'Start of vertical sync' event (X=4)
     lda #osbyte_enable_event                                          ; 1409: a9 0e       ..
-    ldx #5                                                            ; 140b: a2 05       ..
+    ldx #event_interval_timer_crossing_zero                           ; 140b: a2 05       ..
     ldy #0                                                            ; 140d: a0 00       ..
     jsr osbyte                                                        ; 140f: 20 f4 ff     ..            ; Enable 'Interval timer crossing zero' event (X=5)
     lda #osbyte_enable_event                                          ; 1412: a9 0e       ..
-    ldx #6                                                            ; 1414: a2 06       ..
+    ldx #event_escape_condition_detected                              ; 1414: a2 06       ..
     ldy #0                                                            ; 1416: a0 00       ..
     jsr osbyte                                                        ; 1418: 20 f4 ff     ..            ; Enable 'ESCAPE condition detected' event (X=6)
     lda #osbyte_enable_event                                          ; 141b: a9 0e       ..
-    ldx #7                                                            ; 141d: a2 07       ..
+    ldx #event_rs423_error                                            ; 141d: a2 07       ..
     ldy #0                                                            ; 141f: a0 00       ..
     jsr osbyte                                                        ; 1421: 20 f4 ff     ..            ; Enable 'RS423 error' event (X=7)
     lda #osbyte_enable_event                                          ; 1424: a9 0e       ..
-    ldx #8                                                            ; 1426: a2 08       ..
+    ldx #event_network_error                                          ; 1426: a2 08       ..
     ldy #0                                                            ; 1428: a0 00       ..
     jsr osbyte                                                        ; 142a: 20 f4 ff     ..            ; Enable 'Network error' event (X=8)
     lda #osbyte_enable_event                                          ; 142d: a9 0e       ..
-    ldx #9                                                            ; 142f: a2 09       ..
+    ldx #event_user                                                   ; 142f: a2 09       ..
     ldy #0                                                            ; 1431: a0 00       ..
     jsr osbyte                                                        ; 1433: 20 f4 ff     ..            ; Enable 'User' event (X=9)
     lda #osbyte_enable_event                                          ; 1436: a9 0e       ..
@@ -771,39 +805,39 @@ osbyte  = &fff4
     ldy #0                                                            ; 150f: a0 00       ..
     jsr osbyte                                                        ; 1511: 20 f4 ff     ..            ; Flush specific buffer X
     lda #osbyte_flush_buffer                                          ; 1514: a9 15       ..
-    ldx #0                                                            ; 1516: a2 00       ..
+    ldx #buffer_keyboard                                              ; 1516: a2 00       ..
     ldy #0                                                            ; 1518: a0 00       ..
     jsr osbyte                                                        ; 151a: 20 f4 ff     ..            ; Flush the keyboard buffer (X=0)
     lda #osbyte_flush_buffer                                          ; 151d: a9 15       ..
-    ldx #1                                                            ; 151f: a2 01       ..
+    ldx #buffer_rs423_input                                           ; 151f: a2 01       ..
     ldy #0                                                            ; 1521: a0 00       ..
     jsr osbyte                                                        ; 1523: 20 f4 ff     ..            ; Flush the RS423 input buffer (X=1)
     lda #osbyte_flush_buffer                                          ; 1526: a9 15       ..
-    ldx #2                                                            ; 1528: a2 02       ..
+    ldx #buffer_rs423_output                                          ; 1528: a2 02       ..
     ldy #0                                                            ; 152a: a0 00       ..
     jsr osbyte                                                        ; 152c: 20 f4 ff     ..            ; Flush the RS423 output buffer (X=2)
     lda #osbyte_flush_buffer                                          ; 152f: a9 15       ..
-    ldx #3                                                            ; 1531: a2 03       ..
+    ldx #buffer_printer                                               ; 1531: a2 03       ..
     ldy #0                                                            ; 1533: a0 00       ..
     jsr osbyte                                                        ; 1535: 20 f4 ff     ..            ; Flush the printer buffer (X=3)
     lda #osbyte_flush_buffer                                          ; 1538: a9 15       ..
-    ldx #4                                                            ; 153a: a2 04       ..
+    ldx #buffer_sound_channel_0                                       ; 153a: a2 04       ..
     ldy #0                                                            ; 153c: a0 00       ..
     jsr osbyte                                                        ; 153e: 20 f4 ff     ..            ; Flush sound channel 0 (X=4)
     lda #osbyte_flush_buffer                                          ; 1541: a9 15       ..
-    ldx #5                                                            ; 1543: a2 05       ..
+    ldx #buffer_sound_channel_1                                       ; 1543: a2 05       ..
     ldy #0                                                            ; 1545: a0 00       ..
     jsr osbyte                                                        ; 1547: 20 f4 ff     ..            ; Flush sound channel 1 (X=5)
     lda #osbyte_flush_buffer                                          ; 154a: a9 15       ..
-    ldx #6                                                            ; 154c: a2 06       ..
+    ldx #buffer_sound_channel_2                                       ; 154c: a2 06       ..
     ldy #0                                                            ; 154e: a0 00       ..
     jsr osbyte                                                        ; 1550: 20 f4 ff     ..            ; Flush sound channel 2 (X=6)
     lda #osbyte_flush_buffer                                          ; 1553: a9 15       ..
-    ldx #7                                                            ; 1555: a2 07       ..
+    ldx #buffer_sound_channel_3                                       ; 1555: a2 07       ..
     ldy #0                                                            ; 1557: a0 00       ..
     jsr osbyte                                                        ; 1559: 20 f4 ff     ..            ; Flush sound channel 3 (X=7)
     lda #osbyte_flush_buffer                                          ; 155c: a9 15       ..
-    ldx #8                                                            ; 155e: a2 08       ..
+    ldx #buffer_speech                                                ; 155e: a2 08       ..
     ldy #0                                                            ; 1560: a0 00       ..
     jsr osbyte                                                        ; 1562: 20 f4 ff     ..            ; Flush the speech buffer (X=8)
     lda #osbyte_flush_buffer                                          ; 1565: a9 15       ..
@@ -931,15 +965,15 @@ osbyte  = &fff4
     jsr osbyte                                                        ; 162d: 20 f4 ff     ..            ; Keyboard scan, or test for a specific key
     cpx #0                                                            ; 1630: e0 00       ..             ; X is either the internal key number (0-127) pressed (for a keyboard scan), or the top bit is the key state (when testing a specific key)
     lda #osbyte_scan_keyboard                                         ; 1632: a9 79       .y
-    ldx #0                                                            ; 1634: a2 00       ..
+    ldx #255 - inkey_key_shift                                        ; 1634: a2 00       ..             ; X=internal key number
     jsr osbyte                                                        ; 1636: 20 f4 ff     ..            ; Keyboard scan starting from 'SHIFT' key (X=0)
     cpx #0                                                            ; 1639: e0 00       ..             ; X is the internal key number (0-127) if a key is pressed, or &ff otherwise
     lda #osbyte_scan_keyboard                                         ; 163b: a9 79       .y
-    ldx #1                                                            ; 163d: a2 01       ..
+    ldx #255 - inkey_key_ctrl                                         ; 163d: a2 01       ..             ; X=internal key number
     jsr osbyte                                                        ; 163f: 20 f4 ff     ..            ; Keyboard scan starting from 'CTRL' key (X=1)
     cpx #0                                                            ; 1642: e0 00       ..             ; X is the internal key number (0-127) if a key is pressed, or &ff otherwise
     lda #osbyte_scan_keyboard                                         ; 1644: a9 79       .y
-    ldx #&80                                                          ; 1646: a2 80       ..
+    ldx #(255 - inkey_key_shift) EOR 128                              ; 1646: a2 80       ..             ; X=internal key number EOR 128
     jsr osbyte                                                        ; 1648: 20 f4 ff     ..            ; Test for 'SHIFT' key pressed (X=128)
     cpx #0                                                            ; 164b: e0 00       ..             ; X has top bit set if 'SHIFT' pressed
     lda #osbyte_scan_keyboard                                         ; 164d: a9 79       .y
@@ -947,7 +981,7 @@ osbyte  = &fff4
     jsr osbyte                                                        ; 1651: 20 f4 ff     ..            ; Test for an unknown key pressed (X=255)
     cpx #0                                                            ; 1654: e0 00       ..             ; X has top bit set if an unknown pressed
     lda #osbyte_scan_keyboard                                         ; 1656: a9 79       .y
-    ldx #&20 ; ' '                                                    ; 1658: a2 20       .
+    ldx #255 - inkey_key_f0                                           ; 1658: a2 20       .              ; X=internal key number
     jsr osbyte                                                        ; 165a: 20 f4 ff     ..            ; Keyboard scan starting from 'F0' key (X=32)
     cpx #0                                                            ; 165d: e0 00       ..             ; X is the internal key number (0-127) if a key is pressed, or &ff otherwise
 
@@ -1115,7 +1149,7 @@ osbyte  = &fff4
     ;     X=245, Master Compact OS 5.10
     cpx #0                                                            ; 178a: e0 00       ..
     lda #osbyte_inkey                                                 ; 178c: a9 81       ..
-    ldx #inkey_key_shift                                              ; 178e: a2 ff       ..
+    ldx #inkey_key_shift                                              ; 178e: a2 ff       ..             ; X=inkey key value
     ldy #&80                                                          ; 1790: a0 80       ..
     jsr osbyte                                                        ; 1792: 20 f4 ff     ..            ; Is the 'SHIFT' key pressed?
     cpy #0                                                            ; 1795: c0 00       ..             ; X and Y contain &ff if the key is pressed
@@ -1246,43 +1280,43 @@ osbyte  = &fff4
     ldy #0                                                            ; 1881: a0 00       ..
     jsr osbyte                                                        ; 1883: 20 f4 ff     ..            ; Insert value 0 into buffer X; carry is clear if successful
     lda #osbyte_insert_buffer                                         ; 1886: a9 8a       ..
-    ldx #1                                                            ; 1888: a2 01       ..
+    ldx #buffer_rs423_input                                           ; 1888: a2 01       ..
     ldy mem                                                           ; 188a: a4 70       .p
     jsr osbyte                                                        ; 188c: 20 f4 ff     ..            ; Insert value Y into the RS423 input buffer (X=1); carry is clear if successful
     lda #osbyte_insert_buffer                                         ; 188f: a9 8a       ..
-    ldx #0                                                            ; 1891: a2 00       ..
+    ldx #buffer_keyboard                                              ; 1891: a2 00       ..
     ldy #2                                                            ; 1893: a0 02       ..
     jsr osbyte                                                        ; 1895: 20 f4 ff     ..            ; Insert value 2 into the keyboard buffer (X=0); carry is clear if successful
     lda #osbyte_insert_buffer                                         ; 1898: a9 8a       ..
-    ldx #1                                                            ; 189a: a2 01       ..
+    ldx #buffer_rs423_input                                           ; 189a: a2 01       ..
     ldy #3                                                            ; 189c: a0 03       ..
     jsr osbyte                                                        ; 189e: 20 f4 ff     ..            ; Insert value 3 into the RS423 input buffer (X=1); carry is clear if successful
     lda #osbyte_insert_buffer                                         ; 18a1: a9 8a       ..
-    ldx #2                                                            ; 18a3: a2 02       ..
+    ldx #buffer_rs423_output                                          ; 18a3: a2 02       ..
     ldy #&63 ; 'c'                                                    ; 18a5: a0 63       .c
     jsr osbyte                                                        ; 18a7: 20 f4 ff     ..            ; Insert value 99 into the RS423 output buffer (X=2); carry is clear if successful
     lda #osbyte_insert_buffer                                         ; 18aa: a9 8a       ..
-    ldx #3                                                            ; 18ac: a2 03       ..
+    ldx #buffer_printer                                               ; 18ac: a2 03       ..
     ldy #&17                                                          ; 18ae: a0 17       ..
     jsr osbyte                                                        ; 18b0: 20 f4 ff     ..            ; Insert value 23 into the printer buffer (X=3); carry is clear if successful
     lda #osbyte_insert_buffer                                         ; 18b3: a9 8a       ..
-    ldx #4                                                            ; 18b5: a2 04       ..
+    ldx #buffer_sound_channel_0                                       ; 18b5: a2 04       ..
     ldy #&ce                                                          ; 18b7: a0 ce       ..
     jsr osbyte                                                        ; 18b9: 20 f4 ff     ..            ; Insert value 206 into sound channel 0 (X=4); carry is clear if successful
     lda #osbyte_insert_buffer                                         ; 18bc: a9 8a       ..
-    ldx #5                                                            ; 18be: a2 05       ..
+    ldx #buffer_sound_channel_1                                       ; 18be: a2 05       ..
     ldy #&63 ; 'c'                                                    ; 18c0: a0 63       .c
     jsr osbyte                                                        ; 18c2: 20 f4 ff     ..            ; Insert value 99 into sound channel 1 (X=5); carry is clear if successful
     lda #osbyte_insert_buffer                                         ; 18c5: a9 8a       ..
-    ldx #6                                                            ; 18c7: a2 06       ..
+    ldx #buffer_sound_channel_2                                       ; 18c7: a2 06       ..
     ldy #&2a ; '*'                                                    ; 18c9: a0 2a       .*
     jsr osbyte                                                        ; 18cb: 20 f4 ff     ..            ; Insert value 42 into sound channel 2 (X=6); carry is clear if successful
     lda #osbyte_insert_buffer                                         ; 18ce: a9 8a       ..
-    ldx #7                                                            ; 18d0: a2 07       ..
+    ldx #buffer_sound_channel_3                                       ; 18d0: a2 07       ..
     ldy #1                                                            ; 18d2: a0 01       ..
     jsr osbyte                                                        ; 18d4: 20 f4 ff     ..            ; Insert value 1 into sound channel 3 (X=7); carry is clear if successful
     lda #osbyte_insert_buffer                                         ; 18d7: a9 8a       ..
-    ldx #8                                                            ; 18d9: a2 08       ..
+    ldx #buffer_speech                                                ; 18d9: a2 08       ..
     ldy #&5a ; 'Z'                                                    ; 18db: a0 5a       .Z
     jsr osbyte                                                        ; 18dd: 20 f4 ff     ..            ; Insert value 90 into the speech buffer (X=8); carry is clear if successful
     lda #osbyte_insert_buffer                                         ; 18e0: a9 8a       ..
@@ -1638,7 +1672,7 @@ osbyte  = &fff4
 
     ; *************** Test OSBYTE 0x91 ***************
     lda #osbyte_read_buffer                                           ; 1bd8: a9 91       ..
-    ldx #0                                                            ; 1bda: a2 00       ..
+    ldx #buffer_keyboard                                              ; 1bda: a2 00       ..
     ldy #0                                                            ; 1bdc: a0 00       ..
     jsr osbyte                                                        ; 1bde: 20 f4 ff     ..            ; Get character from keyboard buffer (C is set if the buffer is empty, otherwise Y=extracted character)
     bcs buffer_empty                                                  ; 1be1: b0 02       ..
@@ -1733,31 +1767,31 @@ osbyte  = &fff4
     ldy #0                                                            ; 1c85: a0 00       ..
     jsr osbyte                                                        ; 1c87: 20 f4 ff     ..            ; Examine status of buffer X (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        ; 1c8a: a9 98       ..
-    ldx #0                                                            ; 1c8c: a2 00       ..
+    ldx #buffer_keyboard                                              ; 1c8c: a2 00       ..
     jsr osbyte                                                        ; 1c8e: 20 f4 ff     ..            ; Examine the keyboard buffer (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        ; 1c91: a9 98       ..
-    ldx #1                                                            ; 1c93: a2 01       ..
+    ldx #buffer_rs423_input                                           ; 1c93: a2 01       ..
     jsr osbyte                                                        ; 1c95: 20 f4 ff     ..            ; Examine the RS423 input buffer (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        ; 1c98: a9 98       ..
-    ldx #2                                                            ; 1c9a: a2 02       ..
+    ldx #buffer_rs423_output                                          ; 1c9a: a2 02       ..
     jsr osbyte                                                        ; 1c9c: 20 f4 ff     ..            ; Examine the RS423 output buffer (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        ; 1c9f: a9 98       ..
-    ldx #3                                                            ; 1ca1: a2 03       ..
+    ldx #buffer_printer                                               ; 1ca1: a2 03       ..
     jsr osbyte                                                        ; 1ca3: 20 f4 ff     ..            ; Examine the printer buffer (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        ; 1ca6: a9 98       ..
-    ldx #4                                                            ; 1ca8: a2 04       ..
+    ldx #buffer_sound_channel_0                                       ; 1ca8: a2 04       ..
     jsr osbyte                                                        ; 1caa: 20 f4 ff     ..            ; Examine sound channel 0 (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        ; 1cad: a9 98       ..
-    ldx #5                                                            ; 1caf: a2 05       ..
+    ldx #buffer_sound_channel_1                                       ; 1caf: a2 05       ..
     jsr osbyte                                                        ; 1cb1: 20 f4 ff     ..            ; Examine sound channel 1 (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        ; 1cb4: a9 98       ..
-    ldx #6                                                            ; 1cb6: a2 06       ..
+    ldx #buffer_sound_channel_2                                       ; 1cb6: a2 06       ..
     jsr osbyte                                                        ; 1cb8: 20 f4 ff     ..            ; Examine sound channel 2 (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        ; 1cbb: a9 98       ..
-    ldx #7                                                            ; 1cbd: a2 07       ..
+    ldx #buffer_sound_channel_3                                       ; 1cbd: a2 07       ..
     jsr osbyte                                                        ; 1cbf: 20 f4 ff     ..            ; Examine sound channel 3 (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        ; 1cc2: a9 98       ..
-    ldx #8                                                            ; 1cc4: a2 08       ..
+    ldx #buffer_speech                                                ; 1cc4: a2 08       ..
     jsr osbyte                                                        ; 1cc6: 20 f4 ff     ..            ; Examine the speech buffer (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        ; 1cc9: a9 98       ..
     ldx #9                                                            ; 1ccb: a2 09       ..
@@ -4456,29 +4490,29 @@ osbyte  = &fff4
     lda #4                                                            ; 31ba: a9 04       ..             ; A=value to be written
     ldy #&5a ; 'Z'                                                    ; 31bc: a0 5a       .Z             ; Y=offset from base address
     jsr oswrsc                                                        ; 31be: 20 b3 ff     ..            ; Write byte to screen
-    ldy #2                                                            ; 31c1: a0 02       ..
+    ldy #event_character_entering_input_buffer                        ; 31c1: a0 02       ..
     jsr oseven                                                        ; 31c3: 20 bf ff     ..            ; Generate event Y='Character entering input buffer'
     jsr osrdch                                                        ; 31c6: 20 e0 ff     ..            ; Read a character from the current input stream
     cmp #&20 ; ' '                                                    ; 31c9: c9 20       .              ; A=character read
     jsr nvrdch                                                        ; 31cb: 20 c8 ff     ..            ; Read a character from the current input stream
     cmp #&2a ; '*'                                                    ; 31ce: c9 2a       .*             ; A=character read
-    lda #0                                                            ; 31d0: a9 00       ..
+    lda #osfind_close                                                 ; 31d0: a9 00       ..
     ldy #0                                                            ; 31d2: a0 00       ..
     jsr osfind                                                        ; 31d4: 20 ce ff     ..            ; Close all files (Y=0)
-    lda #0                                                            ; 31d7: a9 00       ..
+    lda #osfind_close                                                 ; 31d7: a9 00       ..
     ldy #1                                                            ; 31d9: a0 01       ..
     jsr osfind                                                        ; 31db: 20 ce ff     ..            ; Close file Y
-    lda #&40 ; '@'                                                    ; 31de: a9 40       .@
+    lda #osfind_open_input                                            ; 31de: a9 40       .@
     ldx #<(osfind_block)                                              ; 31e0: a2 c7       ..
     ldy #>(osfind_block)                                              ; 31e2: a0 41       .A
     jsr osfind                                                        ; 31e4: 20 ce ff     ..            ; Open file for input (A=64)
     sta mem                                                           ; 31e7: 85 70       .p             ; A=file handle (or zero on failure)
-    lda #&80                                                          ; 31e9: a9 80       ..
+    lda #osfind_open_output                                           ; 31e9: a9 80       ..
     ldx #<(osfind_block)                                              ; 31eb: a2 c7       ..
     ldy #>(osfind_block)                                              ; 31ed: a0 41       .A
     jsr osfind                                                        ; 31ef: 20 ce ff     ..            ; Open file for output (A=128)
     sta mem                                                           ; 31f2: 85 70       .p             ; A=file handle (or zero on failure)
-    lda #&c0                                                          ; 31f4: a9 c0       ..
+    lda #osfind_open_random_access                                    ; 31f4: a9 c0       ..
     ldx #<(osfind_block)                                              ; 31f6: a2 c7       ..
     ldy #>(osfind_block)                                              ; 31f8: a0 41       .A
     jsr osfind                                                        ; 31fa: 20 ce ff     ..            ; Open file for random access (A=192)
@@ -5832,6 +5866,10 @@ osbyte  = &fff4
 ;     osnewl:         1
 ;     oswrcr:         1
 ;     oswrch:         1
+    assert (255 - inkey_key_shift) EOR 128 == &80
+    assert 255 - inkey_key_ctrl == &01
+    assert 255 - inkey_key_f0 == &20
+    assert 255 - inkey_key_shift == &00
     assert <(input_buffer) == &05
     assert <(osfile_block) == &99
     assert <(osfind_block) == &c7
@@ -5876,6 +5914,34 @@ osbyte  = &fff4
     assert >(osword7block) == &40
     assert >(osword8block) == &40
     assert >(osword9block) == &40
+    assert baud_rate_1200 == &04
+    assert baud_rate_150 == &02
+    assert baud_rate_19200 == &08
+    assert baud_rate_2400 == &05
+    assert baud_rate_300 == &03
+    assert baud_rate_4800 == &06
+    assert baud_rate_75 == &01
+    assert baud_rate_9600 == &07
+    assert baud_rate_default_9600 == &00
+    assert buffer_keyboard == &00
+    assert buffer_printer == &03
+    assert buffer_rs423_input == &01
+    assert buffer_rs423_output == &02
+    assert buffer_sound_channel_0 == &04
+    assert buffer_sound_channel_1 == &05
+    assert buffer_sound_channel_2 == &06
+    assert buffer_sound_channel_3 == &07
+    assert buffer_speech == &08
+    assert event_adc_conversion_complete == &03
+    assert event_character_entering_input_buffer == &02
+    assert event_escape_condition_detected == &06
+    assert event_input_buffer_full == &01
+    assert event_interval_timer_crossing_zero == &05
+    assert event_network_error == &08
+    assert event_output_buffer_empty == &00
+    assert event_rs423_error == &07
+    assert event_start_of_vertical_sync == &04
+    assert event_user == &09
     assert inkey_key_shift == &ff
     assert osbyte_acknowledge_escape == &7e
     assert osbyte_check_eof == &7f
@@ -6054,6 +6120,10 @@ osbyte  = &fff4
     assert osfile_write_catalogue_info == &01
     assert osfile_write_exec_addr == &03
     assert osfile_write_load_addr == &02
+    assert osfind_close == &00
+    assert osfind_open_input == &40
+    assert osfind_open_output == &80
+    assert osfind_open_random_access == &c0
     assert osgbpb_append_bytes == &02
     assert osgbpb_read_bytes_from_current_position == &04
     assert osgbpb_read_bytes_from_position == &03

--- a/examples/known_good/acorn_os_calls_xa.asm
+++ b/examples/known_good/acorn_os_calls_xa.asm
@@ -4572,7 +4572,7 @@ buffer_empty
     ldy mem                                                           // 3275: a4 70       .p             // Y=file handle
     jsr osbget                                                        // 3277: 20 d7 ff     ..            // Read a single byte from an open file Y
     cmp #0                                                            // 327a: c9 00       ..
-    jsr osnewl                                                        // 327c: 20 e7 ff     ..            // Write newline (character 10)
+    jsr osnewl                                                        // 327c: 20 e7 ff     ..            // Write newline (characters 10 and 13)
     jsr oswrcr                                                        // 327f: 20 ec ff     ..            // Write carriage return (character 13)
     lda #$41 // 'A'                                                   // 3282: a9 41       .A
     jsr oswrch                                                        // 3284: 20 ee ff     ..            // Write character 65

--- a/examples/known_good/acorn_os_calls_xa.asm
+++ b/examples/known_good/acorn_os_calls_xa.asm
@@ -1,4 +1,34 @@
 // Constants
+baud_rate_1200                                     = 4
+baud_rate_150                                      = 2
+baud_rate_19200                                    = 8
+baud_rate_2400                                     = 5
+baud_rate_300                                      = 3
+baud_rate_4800                                     = 6
+baud_rate_75                                       = 1
+baud_rate_9600                                     = 7
+baud_rate_default_9600                             = 0
+buffer_keyboard                                    = 0
+buffer_printer                                     = 3
+buffer_rs423_input                                 = 1
+buffer_rs423_output                                = 2
+buffer_sound_channel_0                             = 4
+buffer_sound_channel_1                             = 5
+buffer_sound_channel_2                             = 6
+buffer_sound_channel_3                             = 7
+buffer_speech                                      = 8
+event_adc_conversion_complete                      = 3
+event_character_entering_input_buffer              = 2
+event_escape_condition_detected                    = 6
+event_input_buffer_full                            = 1
+event_interval_timer_crossing_zero                 = 5
+event_network_error                                = 8
+event_output_buffer_empty                          = 0
+event_rs423_error                                  = 7
+event_start_of_vertical_sync                       = 4
+event_user                                         = 9
+inkey_key_ctrl                                     = 254
+inkey_key_f0                                       = 223
 inkey_key_shift                                    = 255
 osbyte_acknowledge_escape                          = 126
 osbyte_check_eof                                   = 127
@@ -177,6 +207,10 @@ osfile_write_attributes                            = 4
 osfile_write_catalogue_info                        = 1
 osfile_write_exec_addr                             = 3
 osfile_write_load_addr                             = 2
+osfind_close                                       = 0
+osfind_open_input                                  = 64
+osfind_open_output                                 = 128
+osfind_open_random_access                          = 192
 osgbpb_append_bytes                                = 2
 osgbpb_read_bytes_from_current_position            = 4
 osgbpb_read_bytes_from_position                    = 3
@@ -311,19 +345,19 @@ pydis_start
     lda #osbyte_set_cursor_editing                                    // 118f: a9 04       ..
     ldx #0                                                            // 1191: a2 00       ..
     ldy #0                                                            // 1193: a0 00       ..
-    jsr osbyte                                                        // 1195: 20 f4 ff     ..            // Enable cursor editing
+    jsr osbyte                                                        // 1195: 20 f4 ff     ..            // Enable cursor editing (X=0)
     lda #osbyte_set_cursor_editing                                    // 1198: a9 04       ..
     ldx #1                                                            // 119a: a2 01       ..
     ldy #0                                                            // 119c: a0 00       ..
-    jsr osbyte                                                        // 119e: 20 f4 ff     ..            // Disable cursor editing (edit keys give ASCII 135-139)
+    jsr osbyte                                                        // 119e: 20 f4 ff     ..            // Disable cursor editing (edit keys give ASCII 135-139) (X=1)
     lda #osbyte_set_cursor_editing                                    // 11a1: a9 04       ..
     ldx #2                                                            // 11a3: a2 02       ..
     ldy #0                                                            // 11a5: a0 00       ..
-    jsr osbyte                                                        // 11a7: 20 f4 ff     ..            // Disable cursor editing (edit keys act as soft keys f11 to f15)
+    jsr osbyte                                                        // 11a7: 20 f4 ff     ..            // Disable cursor editing (edit keys act as soft keys f11 to f15) (X=2)
     lda #osbyte_set_cursor_editing                                    // 11aa: a9 04       ..
     ldx #3                                                            // 11ac: a2 03       ..
     ldy #0                                                            // 11ae: a0 00       ..
-    jsr osbyte                                                        // 11b0: 20 f4 ff     ..            // Cursor editing keys and COPY simulate a joystick (Master Compact only)
+    jsr osbyte                                                        // 11b0: 20 f4 ff     ..            // Cursor editing keys and COPY simulate a joystick (Master Compact only) (X=3)
     lda #osbyte_set_cursor_editing                                    // 11b3: a9 04       ..
     ldx #4                                                            // 11b5: a2 04       ..
     ldy #0                                                            // 11b7: a0 00       ..
@@ -392,39 +426,39 @@ pydis_start
     ldy #0                                                            // 1217: a0 00       ..
     jsr osbyte                                                        // 1219: 20 f4 ff     ..            // Set serial receive rate based on X
     lda #osbyte_set_serial_receive_rate                               // 121c: a9 07       ..
-    ldx #0                                                            // 121e: a2 00       ..
+    ldx #baud_rate_default_9600                                       // 121e: a2 00       ..
     ldy #0                                                            // 1220: a0 00       ..
-    jsr osbyte                                                        // 1222: 20 f4 ff     ..            // Set serial receive rate to 9600 baud (X=0)
+    jsr osbyte                                                        // 1222: 20 f4 ff     ..            // Set serial receive rate to default 9600 baud (X=0)
     lda #osbyte_set_serial_receive_rate                               // 1225: a9 07       ..
-    ldx #1                                                            // 1227: a2 01       ..
+    ldx #baud_rate_75                                                 // 1227: a2 01       ..
     ldy #0                                                            // 1229: a0 00       ..
     jsr osbyte                                                        // 122b: 20 f4 ff     ..            // Set serial receive rate to 75 baud (X=1)
     lda #osbyte_set_serial_receive_rate                               // 122e: a9 07       ..
-    ldx #2                                                            // 1230: a2 02       ..
+    ldx #baud_rate_150                                                // 1230: a2 02       ..
     ldy #0                                                            // 1232: a0 00       ..
     jsr osbyte                                                        // 1234: 20 f4 ff     ..            // Set serial receive rate to 150 baud (X=2)
     lda #osbyte_set_serial_receive_rate                               // 1237: a9 07       ..
-    ldx #3                                                            // 1239: a2 03       ..
+    ldx #baud_rate_300                                                // 1239: a2 03       ..
     ldy #0                                                            // 123b: a0 00       ..
     jsr osbyte                                                        // 123d: 20 f4 ff     ..            // Set serial receive rate to 300 baud (X=3)
     lda #osbyte_set_serial_receive_rate                               // 1240: a9 07       ..
-    ldx #4                                                            // 1242: a2 04       ..
+    ldx #baud_rate_1200                                               // 1242: a2 04       ..
     ldy #0                                                            // 1244: a0 00       ..
     jsr osbyte                                                        // 1246: 20 f4 ff     ..            // Set serial receive rate to 1200 baud (X=4)
     lda #osbyte_set_serial_receive_rate                               // 1249: a9 07       ..
-    ldx #5                                                            // 124b: a2 05       ..
+    ldx #baud_rate_2400                                               // 124b: a2 05       ..
     ldy #0                                                            // 124d: a0 00       ..
     jsr osbyte                                                        // 124f: 20 f4 ff     ..            // Set serial receive rate to 2400 baud (X=5)
     lda #osbyte_set_serial_receive_rate                               // 1252: a9 07       ..
-    ldx #6                                                            // 1254: a2 06       ..
+    ldx #baud_rate_4800                                               // 1254: a2 06       ..
     ldy #0                                                            // 1256: a0 00       ..
     jsr osbyte                                                        // 1258: 20 f4 ff     ..            // Set serial receive rate to 4800 baud (X=6)
     lda #osbyte_set_serial_receive_rate                               // 125b: a9 07       ..
-    ldx #7                                                            // 125d: a2 07       ..
+    ldx #baud_rate_9600                                               // 125d: a2 07       ..
     ldy #0                                                            // 125f: a0 00       ..
     jsr osbyte                                                        // 1261: 20 f4 ff     ..            // Set serial receive rate to 9600 baud (X=7)
     lda #osbyte_set_serial_receive_rate                               // 1264: a9 07       ..
-    ldx #8                                                            // 1266: a2 08       ..
+    ldx #baud_rate_19200                                              // 1266: a2 08       ..
     ldy #0                                                            // 1268: a0 00       ..
     jsr osbyte                                                        // 126a: 20 f4 ff     ..            // Set serial receive rate to 19200 baud (X=8)
     lda #osbyte_set_serial_receive_rate                               // 126d: a9 07       ..
@@ -446,39 +480,39 @@ pydis_start
     ldy #0                                                            // 127e: a0 00       ..
     jsr osbyte                                                        // 1280: 20 f4 ff     ..            // Set serial transmission rate based on X
     lda #osbyte_set_serial_transmit_rate                              // 1283: a9 08       ..
-    ldx #0                                                            // 1285: a2 00       ..
+    ldx #baud_rate_default_9600                                       // 1285: a2 00       ..
     ldy #0                                                            // 1287: a0 00       ..
-    jsr osbyte                                                        // 1289: 20 f4 ff     ..            // Set serial transmission rate to 9600 baud (X=0)
+    jsr osbyte                                                        // 1289: 20 f4 ff     ..            // Set serial transmission rate to default 9600 baud (X=0)
     lda #osbyte_set_serial_transmit_rate                              // 128c: a9 08       ..
-    ldx #1                                                            // 128e: a2 01       ..
+    ldx #baud_rate_75                                                 // 128e: a2 01       ..
     ldy #0                                                            // 1290: a0 00       ..
     jsr osbyte                                                        // 1292: 20 f4 ff     ..            // Set serial transmission rate to 75 baud (X=1)
     lda #osbyte_set_serial_transmit_rate                              // 1295: a9 08       ..
-    ldx #2                                                            // 1297: a2 02       ..
+    ldx #baud_rate_150                                                // 1297: a2 02       ..
     ldy #0                                                            // 1299: a0 00       ..
     jsr osbyte                                                        // 129b: 20 f4 ff     ..            // Set serial transmission rate to 150 baud (X=2)
     lda #osbyte_set_serial_transmit_rate                              // 129e: a9 08       ..
-    ldx #3                                                            // 12a0: a2 03       ..
+    ldx #baud_rate_300                                                // 12a0: a2 03       ..
     ldy #0                                                            // 12a2: a0 00       ..
     jsr osbyte                                                        // 12a4: 20 f4 ff     ..            // Set serial transmission rate to 300 baud (X=3)
     lda #osbyte_set_serial_transmit_rate                              // 12a7: a9 08       ..
-    ldx #4                                                            // 12a9: a2 04       ..
+    ldx #baud_rate_1200                                               // 12a9: a2 04       ..
     ldy #0                                                            // 12ab: a0 00       ..
     jsr osbyte                                                        // 12ad: 20 f4 ff     ..            // Set serial transmission rate to 1200 baud (X=4)
     lda #osbyte_set_serial_transmit_rate                              // 12b0: a9 08       ..
-    ldx #5                                                            // 12b2: a2 05       ..
+    ldx #baud_rate_2400                                               // 12b2: a2 05       ..
     ldy #0                                                            // 12b4: a0 00       ..
     jsr osbyte                                                        // 12b6: 20 f4 ff     ..            // Set serial transmission rate to 2400 baud (X=5)
     lda #osbyte_set_serial_transmit_rate                              // 12b9: a9 08       ..
-    ldx #6                                                            // 12bb: a2 06       ..
+    ldx #baud_rate_4800                                               // 12bb: a2 06       ..
     ldy #0                                                            // 12bd: a0 00       ..
     jsr osbyte                                                        // 12bf: 20 f4 ff     ..            // Set serial transmission rate to 4800 baud (X=6)
     lda #osbyte_set_serial_transmit_rate                              // 12c2: a9 08       ..
-    ldx #7                                                            // 12c4: a2 07       ..
+    ldx #baud_rate_9600                                               // 12c4: a2 07       ..
     ldy #0                                                            // 12c6: a0 00       ..
     jsr osbyte                                                        // 12c8: 20 f4 ff     ..            // Set serial transmission rate to 9600 baud (X=7)
     lda #osbyte_set_serial_transmit_rate                              // 12cb: a9 08       ..
-    ldx #8                                                            // 12cd: a2 08       ..
+    ldx #baud_rate_19200                                              // 12cd: a2 08       ..
     ldy #0                                                            // 12cf: a0 00       ..
     jsr osbyte                                                        // 12d1: 20 f4 ff     ..            // Set serial transmission rate to 19200 baud (X=8)
     lda #osbyte_set_serial_transmit_rate                              // 12d4: a9 08       ..
@@ -571,43 +605,43 @@ pydis_start
 
     // *************** Test OSBYTE 0x0d ***************
     lda #osbyte_disable_event                                         // 1377: a9 0d       ..
-    ldx #0                                                            // 1379: a2 00       ..
+    ldx #event_output_buffer_empty                                    // 1379: a2 00       ..
     ldy #0                                                            // 137b: a0 00       ..
     jsr osbyte                                                        // 137d: 20 f4 ff     ..            // Disable 'Output buffer empty' event (X=0)
     lda #osbyte_disable_event                                         // 1380: a9 0d       ..
-    ldx #1                                                            // 1382: a2 01       ..
+    ldx #event_input_buffer_full                                      // 1382: a2 01       ..
     ldy #0                                                            // 1384: a0 00       ..
     jsr osbyte                                                        // 1386: 20 f4 ff     ..            // Disable 'Input buffer full' event (X=1)
     lda #osbyte_disable_event                                         // 1389: a9 0d       ..
-    ldx #2                                                            // 138b: a2 02       ..
+    ldx #event_character_entering_input_buffer                        // 138b: a2 02       ..
     ldy #0                                                            // 138d: a0 00       ..
     jsr osbyte                                                        // 138f: 20 f4 ff     ..            // Disable 'Character entering input buffer' event (X=2)
     lda #osbyte_disable_event                                         // 1392: a9 0d       ..
-    ldx #3                                                            // 1394: a2 03       ..
+    ldx #event_adc_conversion_complete                                // 1394: a2 03       ..
     ldy #0                                                            // 1396: a0 00       ..
     jsr osbyte                                                        // 1398: 20 f4 ff     ..            // Disable 'ADC conversion complete' event (X=3)
     lda #osbyte_disable_event                                         // 139b: a9 0d       ..
-    ldx #4                                                            // 139d: a2 04       ..
+    ldx #event_start_of_vertical_sync                                 // 139d: a2 04       ..
     ldy #0                                                            // 139f: a0 00       ..
     jsr osbyte                                                        // 13a1: 20 f4 ff     ..            // Disable 'Start of vertical sync' event (X=4)
     lda #osbyte_disable_event                                         // 13a4: a9 0d       ..
-    ldx #5                                                            // 13a6: a2 05       ..
+    ldx #event_interval_timer_crossing_zero                           // 13a6: a2 05       ..
     ldy #0                                                            // 13a8: a0 00       ..
     jsr osbyte                                                        // 13aa: 20 f4 ff     ..            // Disable 'Interval timer crossing zero' event (X=5)
     lda #osbyte_disable_event                                         // 13ad: a9 0d       ..
-    ldx #6                                                            // 13af: a2 06       ..
+    ldx #event_escape_condition_detected                              // 13af: a2 06       ..
     ldy #0                                                            // 13b1: a0 00       ..
     jsr osbyte                                                        // 13b3: 20 f4 ff     ..            // Disable 'ESCAPE condition detected' event (X=6)
     lda #osbyte_disable_event                                         // 13b6: a9 0d       ..
-    ldx #7                                                            // 13b8: a2 07       ..
+    ldx #event_rs423_error                                            // 13b8: a2 07       ..
     ldy #0                                                            // 13ba: a0 00       ..
     jsr osbyte                                                        // 13bc: 20 f4 ff     ..            // Disable 'RS423 error' event (X=7)
     lda #osbyte_disable_event                                         // 13bf: a9 0d       ..
-    ldx #8                                                            // 13c1: a2 08       ..
+    ldx #event_network_error                                          // 13c1: a2 08       ..
     ldy #0                                                            // 13c3: a0 00       ..
     jsr osbyte                                                        // 13c5: 20 f4 ff     ..            // Disable 'Network error' event (X=8)
     lda #osbyte_disable_event                                         // 13c8: a9 0d       ..
-    ldx #9                                                            // 13ca: a2 09       ..
+    ldx #event_user                                                   // 13ca: a2 09       ..
     ldy #0                                                            // 13cc: a0 00       ..
     jsr osbyte                                                        // 13ce: 20 f4 ff     ..            // Disable 'User' event (X=9)
     lda #osbyte_disable_event                                         // 13d1: a9 0d       ..
@@ -618,43 +652,43 @@ pydis_start
 
     // *************** Test OSBYTE 0x0e ***************
     lda #osbyte_enable_event                                          // 13dc: a9 0e       ..
-    ldx #0                                                            // 13de: a2 00       ..
+    ldx #event_output_buffer_empty                                    // 13de: a2 00       ..
     ldy #0                                                            // 13e0: a0 00       ..
     jsr osbyte                                                        // 13e2: 20 f4 ff     ..            // Enable 'Output buffer empty' event (X=0)
     lda #osbyte_enable_event                                          // 13e5: a9 0e       ..
-    ldx #1                                                            // 13e7: a2 01       ..
+    ldx #event_input_buffer_full                                      // 13e7: a2 01       ..
     ldy #0                                                            // 13e9: a0 00       ..
     jsr osbyte                                                        // 13eb: 20 f4 ff     ..            // Enable 'Input buffer full' event (X=1)
     lda #osbyte_enable_event                                          // 13ee: a9 0e       ..
-    ldx #2                                                            // 13f0: a2 02       ..
+    ldx #event_character_entering_input_buffer                        // 13f0: a2 02       ..
     ldy #0                                                            // 13f2: a0 00       ..
     jsr osbyte                                                        // 13f4: 20 f4 ff     ..            // Enable 'Character entering input buffer' event (X=2)
     lda #osbyte_enable_event                                          // 13f7: a9 0e       ..
-    ldx #3                                                            // 13f9: a2 03       ..
+    ldx #event_adc_conversion_complete                                // 13f9: a2 03       ..
     ldy #0                                                            // 13fb: a0 00       ..
     jsr osbyte                                                        // 13fd: 20 f4 ff     ..            // Enable 'ADC conversion complete' event (X=3)
     lda #osbyte_enable_event                                          // 1400: a9 0e       ..
-    ldx #4                                                            // 1402: a2 04       ..
+    ldx #event_start_of_vertical_sync                                 // 1402: a2 04       ..
     ldy #0                                                            // 1404: a0 00       ..
     jsr osbyte                                                        // 1406: 20 f4 ff     ..            // Enable 'Start of vertical sync' event (X=4)
     lda #osbyte_enable_event                                          // 1409: a9 0e       ..
-    ldx #5                                                            // 140b: a2 05       ..
+    ldx #event_interval_timer_crossing_zero                           // 140b: a2 05       ..
     ldy #0                                                            // 140d: a0 00       ..
     jsr osbyte                                                        // 140f: 20 f4 ff     ..            // Enable 'Interval timer crossing zero' event (X=5)
     lda #osbyte_enable_event                                          // 1412: a9 0e       ..
-    ldx #6                                                            // 1414: a2 06       ..
+    ldx #event_escape_condition_detected                              // 1414: a2 06       ..
     ldy #0                                                            // 1416: a0 00       ..
     jsr osbyte                                                        // 1418: 20 f4 ff     ..            // Enable 'ESCAPE condition detected' event (X=6)
     lda #osbyte_enable_event                                          // 141b: a9 0e       ..
-    ldx #7                                                            // 141d: a2 07       ..
+    ldx #event_rs423_error                                            // 141d: a2 07       ..
     ldy #0                                                            // 141f: a0 00       ..
     jsr osbyte                                                        // 1421: 20 f4 ff     ..            // Enable 'RS423 error' event (X=7)
     lda #osbyte_enable_event                                          // 1424: a9 0e       ..
-    ldx #8                                                            // 1426: a2 08       ..
+    ldx #event_network_error                                          // 1426: a2 08       ..
     ldy #0                                                            // 1428: a0 00       ..
     jsr osbyte                                                        // 142a: 20 f4 ff     ..            // Enable 'Network error' event (X=8)
     lda #osbyte_enable_event                                          // 142d: a9 0e       ..
-    ldx #9                                                            // 142f: a2 09       ..
+    ldx #event_user                                                   // 142f: a2 09       ..
     ldy #0                                                            // 1431: a0 00       ..
     jsr osbyte                                                        // 1433: 20 f4 ff     ..            // Enable 'User' event (X=9)
     lda #osbyte_enable_event                                          // 1436: a9 0e       ..
@@ -771,39 +805,39 @@ pydis_start
     ldy #0                                                            // 150f: a0 00       ..
     jsr osbyte                                                        // 1511: 20 f4 ff     ..            // Flush specific buffer X
     lda #osbyte_flush_buffer                                          // 1514: a9 15       ..
-    ldx #0                                                            // 1516: a2 00       ..
+    ldx #buffer_keyboard                                              // 1516: a2 00       ..
     ldy #0                                                            // 1518: a0 00       ..
     jsr osbyte                                                        // 151a: 20 f4 ff     ..            // Flush the keyboard buffer (X=0)
     lda #osbyte_flush_buffer                                          // 151d: a9 15       ..
-    ldx #1                                                            // 151f: a2 01       ..
+    ldx #buffer_rs423_input                                           // 151f: a2 01       ..
     ldy #0                                                            // 1521: a0 00       ..
     jsr osbyte                                                        // 1523: 20 f4 ff     ..            // Flush the RS423 input buffer (X=1)
     lda #osbyte_flush_buffer                                          // 1526: a9 15       ..
-    ldx #2                                                            // 1528: a2 02       ..
+    ldx #buffer_rs423_output                                          // 1528: a2 02       ..
     ldy #0                                                            // 152a: a0 00       ..
     jsr osbyte                                                        // 152c: 20 f4 ff     ..            // Flush the RS423 output buffer (X=2)
     lda #osbyte_flush_buffer                                          // 152f: a9 15       ..
-    ldx #3                                                            // 1531: a2 03       ..
+    ldx #buffer_printer                                               // 1531: a2 03       ..
     ldy #0                                                            // 1533: a0 00       ..
     jsr osbyte                                                        // 1535: 20 f4 ff     ..            // Flush the printer buffer (X=3)
     lda #osbyte_flush_buffer                                          // 1538: a9 15       ..
-    ldx #4                                                            // 153a: a2 04       ..
+    ldx #buffer_sound_channel_0                                       // 153a: a2 04       ..
     ldy #0                                                            // 153c: a0 00       ..
     jsr osbyte                                                        // 153e: 20 f4 ff     ..            // Flush sound channel 0 (X=4)
     lda #osbyte_flush_buffer                                          // 1541: a9 15       ..
-    ldx #5                                                            // 1543: a2 05       ..
+    ldx #buffer_sound_channel_1                                       // 1543: a2 05       ..
     ldy #0                                                            // 1545: a0 00       ..
     jsr osbyte                                                        // 1547: 20 f4 ff     ..            // Flush sound channel 1 (X=5)
     lda #osbyte_flush_buffer                                          // 154a: a9 15       ..
-    ldx #6                                                            // 154c: a2 06       ..
+    ldx #buffer_sound_channel_2                                       // 154c: a2 06       ..
     ldy #0                                                            // 154e: a0 00       ..
     jsr osbyte                                                        // 1550: 20 f4 ff     ..            // Flush sound channel 2 (X=6)
     lda #osbyte_flush_buffer                                          // 1553: a9 15       ..
-    ldx #7                                                            // 1555: a2 07       ..
+    ldx #buffer_sound_channel_3                                       // 1555: a2 07       ..
     ldy #0                                                            // 1557: a0 00       ..
     jsr osbyte                                                        // 1559: 20 f4 ff     ..            // Flush sound channel 3 (X=7)
     lda #osbyte_flush_buffer                                          // 155c: a9 15       ..
-    ldx #8                                                            // 155e: a2 08       ..
+    ldx #buffer_speech                                                // 155e: a2 08       ..
     ldy #0                                                            // 1560: a0 00       ..
     jsr osbyte                                                        // 1562: 20 f4 ff     ..            // Flush the speech buffer (X=8)
     lda #osbyte_flush_buffer                                          // 1565: a9 15       ..
@@ -931,15 +965,15 @@ pydis_start
     jsr osbyte                                                        // 162d: 20 f4 ff     ..            // Keyboard scan, or test for a specific key
     cpx #0                                                            // 1630: e0 00       ..             // X is either the internal key number (0-127) pressed (for a keyboard scan), or the top bit is the key state (when testing a specific key)
     lda #osbyte_scan_keyboard                                         // 1632: a9 79       .y
-    ldx #0                                                            // 1634: a2 00       ..
+    ldx #255 - inkey_key_shift                                        // 1634: a2 00       ..             // X=internal key number
     jsr osbyte                                                        // 1636: 20 f4 ff     ..            // Keyboard scan starting from 'SHIFT' key (X=0)
     cpx #0                                                            // 1639: e0 00       ..             // X is the internal key number (0-127) if a key is pressed, or $ff otherwise
     lda #osbyte_scan_keyboard                                         // 163b: a9 79       .y
-    ldx #1                                                            // 163d: a2 01       ..
+    ldx #255 - inkey_key_ctrl                                         // 163d: a2 01       ..             // X=internal key number
     jsr osbyte                                                        // 163f: 20 f4 ff     ..            // Keyboard scan starting from 'CTRL' key (X=1)
     cpx #0                                                            // 1642: e0 00       ..             // X is the internal key number (0-127) if a key is pressed, or $ff otherwise
     lda #osbyte_scan_keyboard                                         // 1644: a9 79       .y
-    ldx #$80                                                          // 1646: a2 80       ..
+    ldx #(255 - inkey_key_shift) ^ 128                                // 1646: a2 80       ..             // X=internal key number EOR 128
     jsr osbyte                                                        // 1648: 20 f4 ff     ..            // Test for 'SHIFT' key pressed (X=128)
     cpx #0                                                            // 164b: e0 00       ..             // X has top bit set if 'SHIFT' pressed
     lda #osbyte_scan_keyboard                                         // 164d: a9 79       .y
@@ -947,7 +981,7 @@ pydis_start
     jsr osbyte                                                        // 1651: 20 f4 ff     ..            // Test for an unknown key pressed (X=255)
     cpx #0                                                            // 1654: e0 00       ..             // X has top bit set if an unknown pressed
     lda #osbyte_scan_keyboard                                         // 1656: a9 79       .y
-    ldx #$20 // ' '                                                   // 1658: a2 20       .
+    ldx #255 - inkey_key_f0                                           // 1658: a2 20       .              // X=internal key number
     jsr osbyte                                                        // 165a: 20 f4 ff     ..            // Keyboard scan starting from 'F0' key (X=32)
     cpx #0                                                            // 165d: e0 00       ..             // X is the internal key number (0-127) if a key is pressed, or $ff otherwise
 
@@ -1115,7 +1149,7 @@ pydis_start
     //     X=245, Master Compact OS 5.10
     cpx #0                                                            // 178a: e0 00       ..
     lda #osbyte_inkey                                                 // 178c: a9 81       ..
-    ldx #inkey_key_shift                                              // 178e: a2 ff       ..
+    ldx #inkey_key_shift                                              // 178e: a2 ff       ..             // X=inkey key value
     ldy #$80                                                          // 1790: a0 80       ..
     jsr osbyte                                                        // 1792: 20 f4 ff     ..            // Is the 'SHIFT' key pressed?
     cpy #0                                                            // 1795: c0 00       ..             // X and Y contain $ff if the key is pressed
@@ -1246,43 +1280,43 @@ pydis_start
     ldy #0                                                            // 1881: a0 00       ..
     jsr osbyte                                                        // 1883: 20 f4 ff     ..            // Insert value 0 into buffer X; carry is clear if successful
     lda #osbyte_insert_buffer                                         // 1886: a9 8a       ..
-    ldx #1                                                            // 1888: a2 01       ..
+    ldx #buffer_rs423_input                                           // 1888: a2 01       ..
     ldy mem                                                           // 188a: a4 70       .p
     jsr osbyte                                                        // 188c: 20 f4 ff     ..            // Insert value Y into the RS423 input buffer (X=1); carry is clear if successful
     lda #osbyte_insert_buffer                                         // 188f: a9 8a       ..
-    ldx #0                                                            // 1891: a2 00       ..
+    ldx #buffer_keyboard                                              // 1891: a2 00       ..
     ldy #2                                                            // 1893: a0 02       ..
     jsr osbyte                                                        // 1895: 20 f4 ff     ..            // Insert value 2 into the keyboard buffer (X=0); carry is clear if successful
     lda #osbyte_insert_buffer                                         // 1898: a9 8a       ..
-    ldx #1                                                            // 189a: a2 01       ..
+    ldx #buffer_rs423_input                                           // 189a: a2 01       ..
     ldy #3                                                            // 189c: a0 03       ..
     jsr osbyte                                                        // 189e: 20 f4 ff     ..            // Insert value 3 into the RS423 input buffer (X=1); carry is clear if successful
     lda #osbyte_insert_buffer                                         // 18a1: a9 8a       ..
-    ldx #2                                                            // 18a3: a2 02       ..
+    ldx #buffer_rs423_output                                          // 18a3: a2 02       ..
     ldy #$63 // 'c'                                                   // 18a5: a0 63       .c
     jsr osbyte                                                        // 18a7: 20 f4 ff     ..            // Insert value 99 into the RS423 output buffer (X=2); carry is clear if successful
     lda #osbyte_insert_buffer                                         // 18aa: a9 8a       ..
-    ldx #3                                                            // 18ac: a2 03       ..
+    ldx #buffer_printer                                               // 18ac: a2 03       ..
     ldy #$17                                                          // 18ae: a0 17       ..
     jsr osbyte                                                        // 18b0: 20 f4 ff     ..            // Insert value 23 into the printer buffer (X=3); carry is clear if successful
     lda #osbyte_insert_buffer                                         // 18b3: a9 8a       ..
-    ldx #4                                                            // 18b5: a2 04       ..
+    ldx #buffer_sound_channel_0                                       // 18b5: a2 04       ..
     ldy #$ce                                                          // 18b7: a0 ce       ..
     jsr osbyte                                                        // 18b9: 20 f4 ff     ..            // Insert value 206 into sound channel 0 (X=4); carry is clear if successful
     lda #osbyte_insert_buffer                                         // 18bc: a9 8a       ..
-    ldx #5                                                            // 18be: a2 05       ..
+    ldx #buffer_sound_channel_1                                       // 18be: a2 05       ..
     ldy #$63 // 'c'                                                   // 18c0: a0 63       .c
     jsr osbyte                                                        // 18c2: 20 f4 ff     ..            // Insert value 99 into sound channel 1 (X=5); carry is clear if successful
     lda #osbyte_insert_buffer                                         // 18c5: a9 8a       ..
-    ldx #6                                                            // 18c7: a2 06       ..
+    ldx #buffer_sound_channel_2                                       // 18c7: a2 06       ..
     ldy #$2a // '*'                                                   // 18c9: a0 2a       .*
     jsr osbyte                                                        // 18cb: 20 f4 ff     ..            // Insert value 42 into sound channel 2 (X=6); carry is clear if successful
     lda #osbyte_insert_buffer                                         // 18ce: a9 8a       ..
-    ldx #7                                                            // 18d0: a2 07       ..
+    ldx #buffer_sound_channel_3                                       // 18d0: a2 07       ..
     ldy #1                                                            // 18d2: a0 01       ..
     jsr osbyte                                                        // 18d4: 20 f4 ff     ..            // Insert value 1 into sound channel 3 (X=7); carry is clear if successful
     lda #osbyte_insert_buffer                                         // 18d7: a9 8a       ..
-    ldx #8                                                            // 18d9: a2 08       ..
+    ldx #buffer_speech                                                // 18d9: a2 08       ..
     ldy #$5a // 'Z'                                                   // 18db: a0 5a       .Z
     jsr osbyte                                                        // 18dd: 20 f4 ff     ..            // Insert value 90 into the speech buffer (X=8); carry is clear if successful
     lda #osbyte_insert_buffer                                         // 18e0: a9 8a       ..
@@ -1638,7 +1672,7 @@ pydis_start
 
     // *************** Test OSBYTE 0x91 ***************
     lda #osbyte_read_buffer                                           // 1bd8: a9 91       ..
-    ldx #0                                                            // 1bda: a2 00       ..
+    ldx #buffer_keyboard                                              // 1bda: a2 00       ..
     ldy #0                                                            // 1bdc: a0 00       ..
     jsr osbyte                                                        // 1bde: 20 f4 ff     ..            // Get character from keyboard buffer (C is set if the buffer is empty, otherwise Y=extracted character)
     bcs buffer_empty                                                  // 1be1: b0 02       ..
@@ -1733,31 +1767,31 @@ buffer_empty
     ldy #0                                                            // 1c85: a0 00       ..
     jsr osbyte                                                        // 1c87: 20 f4 ff     ..            // Examine status of buffer X (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        // 1c8a: a9 98       ..
-    ldx #0                                                            // 1c8c: a2 00       ..
+    ldx #buffer_keyboard                                              // 1c8c: a2 00       ..
     jsr osbyte                                                        // 1c8e: 20 f4 ff     ..            // Examine the keyboard buffer (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        // 1c91: a9 98       ..
-    ldx #1                                                            // 1c93: a2 01       ..
+    ldx #buffer_rs423_input                                           // 1c93: a2 01       ..
     jsr osbyte                                                        // 1c95: 20 f4 ff     ..            // Examine the RS423 input buffer (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        // 1c98: a9 98       ..
-    ldx #2                                                            // 1c9a: a2 02       ..
+    ldx #buffer_rs423_output                                          // 1c9a: a2 02       ..
     jsr osbyte                                                        // 1c9c: 20 f4 ff     ..            // Examine the RS423 output buffer (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        // 1c9f: a9 98       ..
-    ldx #3                                                            // 1ca1: a2 03       ..
+    ldx #buffer_printer                                               // 1ca1: a2 03       ..
     jsr osbyte                                                        // 1ca3: 20 f4 ff     ..            // Examine the printer buffer (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        // 1ca6: a9 98       ..
-    ldx #4                                                            // 1ca8: a2 04       ..
+    ldx #buffer_sound_channel_0                                       // 1ca8: a2 04       ..
     jsr osbyte                                                        // 1caa: 20 f4 ff     ..            // Examine sound channel 0 (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        // 1cad: a9 98       ..
-    ldx #5                                                            // 1caf: a2 05       ..
+    ldx #buffer_sound_channel_1                                       // 1caf: a2 05       ..
     jsr osbyte                                                        // 1cb1: 20 f4 ff     ..            // Examine sound channel 1 (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        // 1cb4: a9 98       ..
-    ldx #6                                                            // 1cb6: a2 06       ..
+    ldx #buffer_sound_channel_2                                       // 1cb6: a2 06       ..
     jsr osbyte                                                        // 1cb8: 20 f4 ff     ..            // Examine sound channel 2 (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        // 1cbb: a9 98       ..
-    ldx #7                                                            // 1cbd: a2 07       ..
+    ldx #buffer_sound_channel_3                                       // 1cbd: a2 07       ..
     jsr osbyte                                                        // 1cbf: 20 f4 ff     ..            // Examine sound channel 3 (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        // 1cc2: a9 98       ..
-    ldx #8                                                            // 1cc4: a2 08       ..
+    ldx #buffer_speech                                                // 1cc4: a2 08       ..
     jsr osbyte                                                        // 1cc6: 20 f4 ff     ..            // Examine the speech buffer (exits with carry clear on success)
     lda #osbyte_examine_buffer                                        // 1cc9: a9 98       ..
     ldx #9                                                            // 1ccb: a2 09       ..
@@ -4456,29 +4490,29 @@ buffer_empty
     lda #4                                                            // 31ba: a9 04       ..             // A=value to be written
     ldy #$5a // 'Z'                                                   // 31bc: a0 5a       .Z             // Y=offset from base address
     jsr oswrsc                                                        // 31be: 20 b3 ff     ..            // Write byte to screen
-    ldy #2                                                            // 31c1: a0 02       ..
+    ldy #event_character_entering_input_buffer                        // 31c1: a0 02       ..
     jsr oseven                                                        // 31c3: 20 bf ff     ..            // Generate event Y='Character entering input buffer'
     jsr osrdch                                                        // 31c6: 20 e0 ff     ..            // Read a character from the current input stream
     cmp #$20 // ' '                                                   // 31c9: c9 20       .              // A=character read
     jsr nvrdch                                                        // 31cb: 20 c8 ff     ..            // Read a character from the current input stream
     cmp #$2a // '*'                                                   // 31ce: c9 2a       .*             // A=character read
-    lda #0                                                            // 31d0: a9 00       ..
+    lda #osfind_close                                                 // 31d0: a9 00       ..
     ldy #0                                                            // 31d2: a0 00       ..
     jsr osfind                                                        // 31d4: 20 ce ff     ..            // Close all files (Y=0)
-    lda #0                                                            // 31d7: a9 00       ..
+    lda #osfind_close                                                 // 31d7: a9 00       ..
     ldy #1                                                            // 31d9: a0 01       ..
     jsr osfind                                                        // 31db: 20 ce ff     ..            // Close file Y
-    lda #$40 // '@'                                                   // 31de: a9 40       .@
+    lda #osfind_open_input                                            // 31de: a9 40       .@
     ldx #<(osfind_block)                                              // 31e0: a2 c7       ..
     ldy #>(osfind_block)                                              // 31e2: a0 41       .A
     jsr osfind                                                        // 31e4: 20 ce ff     ..            // Open file for input (A=64)
     sta mem                                                           // 31e7: 85 70       .p             // A=file handle (or zero on failure)
-    lda #$80                                                          // 31e9: a9 80       ..
+    lda #osfind_open_output                                           // 31e9: a9 80       ..
     ldx #<(osfind_block)                                              // 31eb: a2 c7       ..
     ldy #>(osfind_block)                                              // 31ed: a0 41       .A
     jsr osfind                                                        // 31ef: 20 ce ff     ..            // Open file for output (A=128)
     sta mem                                                           // 31f2: 85 70       .p             // A=file handle (or zero on failure)
-    lda #$c0                                                          // 31f4: a9 c0       ..
+    lda #osfind_open_random_access                                    // 31f4: a9 c0       ..
     ldx #<(osfind_block)                                              // 31f6: a2 c7       ..
     ldy #>(osfind_block)                                              // 31f8: a0 41       .A
     jsr osfind                                                        // 31fa: 20 ce ff     ..            // Open file for random access (A=192)

--- a/examples/known_good/acorn_os_calls_xa.asm
+++ b/examples/known_good/acorn_os_calls_xa.asm
@@ -78,7 +78,7 @@ osbyte_read_rom_info_table_high                    = 171
 osbyte_read_rom_info_table_low                     = 170
 osbyte_read_rom_ptr_table_high                     = 169
 osbyte_read_rom_ptr_table_low                      = 168
-osbyte_read_serial_control_flag                    = 192
+osbyte_read_serial_control_register_copy           = 192
 osbyte_read_serial_ula                             = 242
 osbyte_read_sheila                                 = 150
 osbyte_read_speech                                 = 158
@@ -106,28 +106,28 @@ osbyte_read_write_bell_channel                     = 211
 osbyte_read_write_bell_duration                    = 214
 osbyte_read_write_bell_envelope                    = 212
 osbyte_read_write_bell_frequency                   = 213
-osbyte_read_write_c0_cf_status                     = 221
 osbyte_read_write_cassette_serial_selection        = 205
 osbyte_read_write_cfs_rfs_switch                   = 183
 osbyte_read_write_cfs_timeout                      = 176
 osbyte_read_write_char_destination_status          = 236
+osbyte_read_write_characters_c0_cf_status          = 221
+osbyte_read_write_characters_d0_df_status          = 222
+osbyte_read_write_characters_e0_ef_status          = 223
+osbyte_read_write_characters_f0_ff_status          = 224
 osbyte_read_write_ctrl_function_key_status         = 227
 osbyte_read_write_ctrl_shift_function_key_status   = 228
 osbyte_read_write_current_language_rom_bank        = 252
 osbyte_read_write_current_oshwm                    = 180
 osbyte_read_write_cursor_editing_status            = 237
-osbyte_read_write_d0_df_status                     = 222
-osbyte_read_write_e0_ef_status                     = 223
 osbyte_read_write_econet_keyboard_disable          = 201
 osbyte_read_write_econet_os_call_interception      = 206
 osbyte_read_write_econet_osrdch_interception       = 207
 osbyte_read_write_econet_oswrch_interception       = 208
 osbyte_read_write_escape_break_effect              = 200
 osbyte_read_write_escape_char                      = 220
-osbyte_read_write_escape_flags                     = 230
+osbyte_read_write_escape_effects                   = 230
 osbyte_read_write_escape_status                    = 229
 osbyte_read_write_exec_file_handle                 = 198
-osbyte_read_write_f0_ff_status                     = 224
 osbyte_read_write_first_byte_break_intercept       = 247
 osbyte_read_write_flash_counter                    = 193
 osbyte_read_write_function_key_status              = 225
@@ -141,7 +141,7 @@ osbyte_read_write_lines_since_last_page            = 217
 osbyte_read_write_mark_count                       = 194
 osbyte_read_write_max_adc_channel                  = 189
 osbyte_read_write_primary_oshwm                    = 179
-osbyte_read_write_printer_destination_flag         = 245
+osbyte_read_write_printer_destination              = 245
 osbyte_read_write_printer_ignore_char              = 246
 osbyte_read_write_rom_bank_at_last_brk             = 186
 osbyte_read_write_second_byte_break_intercept      = 248
@@ -3484,13 +3484,13 @@ buffer_empty
     sty mem                                                           // 2a98: 84 70       .p             // Y=value of OS copy of 6850 (ACIA) control register
 
     // *************** Test OSBYTE 0xc0 ***************
-    lda #osbyte_read_serial_control_flag                              // 2a9a: a9 c0       ..
+    lda #osbyte_read_serial_control_register_copy                     // 2a9a: a9 c0       ..
     ldx #$2a // '*'                                                   // 2a9c: a2 2a       .*
     ldy #0                                                            // 2a9e: a0 00       ..
     jsr osbyte                                                        // 2aa0: 20 f4 ff     ..            // Write OS copy of 6850 (ACIA) control register, value X=42
     stx mem                                                           // 2aa3: 86 70       .p             // X=old value of OS copy of 6850 (ACIA) control register
     sty mem                                                           // 2aa5: 84 70       .p             // Y=value of flash counter in fiftieths of a second
-    lda #osbyte_read_serial_control_flag                              // 2aa7: a9 c0       ..
+    lda #osbyte_read_serial_control_register_copy                     // 2aa7: a9 c0       ..
     ldx #0                                                            // 2aa9: a2 00       ..
     ldy #$ff                                                          // 2aab: a0 ff       ..
     jsr osbyte                                                        // 2aad: 20 f4 ff     ..            // Read OS copy of 6850 (ACIA) control register
@@ -3890,13 +3890,13 @@ buffer_empty
     sty mem                                                           // 2d8a: 84 70       .p             // Y=value of character status flag ($c0-$cf)
 
     // *************** Test OSBYTE 0xdd ***************
-    lda #osbyte_read_write_c0_cf_status                               // 2d8c: a9 dd       ..
+    lda #osbyte_read_write_characters_c0_cf_status                    // 2d8c: a9 dd       ..
     ldx #$2a // '*'                                                   // 2d8e: a2 2a       .*
     ldy #0                                                            // 2d90: a0 00       ..
     jsr osbyte                                                        // 2d92: 20 f4 ff     ..            // Write character status flag ($c0-$cf), value X=42
     stx mem                                                           // 2d95: 86 70       .p             // X=old value of character status flag ($c0-$cf)
     sty mem                                                           // 2d97: 84 70       .p             // Y=value of character status flag ($d0-$df)
-    lda #osbyte_read_write_c0_cf_status                               // 2d99: a9 dd       ..
+    lda #osbyte_read_write_characters_c0_cf_status                    // 2d99: a9 dd       ..
     ldx #0                                                            // 2d9b: a2 00       ..
     ldy #$ff                                                          // 2d9d: a0 ff       ..
     jsr osbyte                                                        // 2d9f: 20 f4 ff     ..            // Read character status flag ($c0-$cf)
@@ -3904,13 +3904,13 @@ buffer_empty
     sty mem                                                           // 2da4: 84 70       .p             // Y=value of character status flag ($d0-$df)
 
     // *************** Test OSBYTE 0xde ***************
-    lda #osbyte_read_write_d0_df_status                               // 2da6: a9 de       ..
+    lda #osbyte_read_write_characters_d0_df_status                    // 2da6: a9 de       ..
     ldx #$2a // '*'                                                   // 2da8: a2 2a       .*
     ldy #0                                                            // 2daa: a0 00       ..
     jsr osbyte                                                        // 2dac: 20 f4 ff     ..            // Write character status flag ($d0-$df), value X=42
     stx mem                                                           // 2daf: 86 70       .p             // X=old value of character status flag ($d0-$df)
     sty mem                                                           // 2db1: 84 70       .p             // Y=value of character status flag ($e0-$ef)
-    lda #osbyte_read_write_d0_df_status                               // 2db3: a9 de       ..
+    lda #osbyte_read_write_characters_d0_df_status                    // 2db3: a9 de       ..
     ldx #0                                                            // 2db5: a2 00       ..
     ldy #$ff                                                          // 2db7: a0 ff       ..
     jsr osbyte                                                        // 2db9: 20 f4 ff     ..            // Read character status flag ($d0-$df)
@@ -3918,13 +3918,13 @@ buffer_empty
     sty mem                                                           // 2dbe: 84 70       .p             // Y=value of character status flag ($e0-$ef)
 
     // *************** Test OSBYTE 0xdf ***************
-    lda #osbyte_read_write_e0_ef_status                               // 2dc0: a9 df       ..
+    lda #osbyte_read_write_characters_e0_ef_status                    // 2dc0: a9 df       ..
     ldx #$2a // '*'                                                   // 2dc2: a2 2a       .*
     ldy #0                                                            // 2dc4: a0 00       ..
     jsr osbyte                                                        // 2dc6: 20 f4 ff     ..            // Write character status flag ($e0-$ef), value X=42
     stx mem                                                           // 2dc9: 86 70       .p             // X=old value of character status flag ($e0-$ef)
     sty mem                                                           // 2dcb: 84 70       .p             // Y=value of character status flag ($f0-$ff)
-    lda #osbyte_read_write_e0_ef_status                               // 2dcd: a9 df       ..
+    lda #osbyte_read_write_characters_e0_ef_status                    // 2dcd: a9 df       ..
     ldx #0                                                            // 2dcf: a2 00       ..
     ldy #$ff                                                          // 2dd1: a0 ff       ..
     jsr osbyte                                                        // 2dd3: 20 f4 ff     ..            // Read character status flag ($e0-$ef)
@@ -3932,13 +3932,13 @@ buffer_empty
     sty mem                                                           // 2dd8: 84 70       .p             // Y=value of character status flag ($f0-$ff)
 
     // *************** Test OSBYTE 0xe0 ***************
-    lda #osbyte_read_write_f0_ff_status                               // 2dda: a9 e0       ..
+    lda #osbyte_read_write_characters_f0_ff_status                    // 2dda: a9 e0       ..
     ldx #$2a // '*'                                                   // 2ddc: a2 2a       .*
     ldy #0                                                            // 2dde: a0 00       ..
     jsr osbyte                                                        // 2de0: 20 f4 ff     ..            // Write character status flag ($f0-$ff), value X=42
     stx mem                                                           // 2de3: 86 70       .p             // X=old value of character status flag ($f0-$ff)
     sty mem                                                           // 2de5: 84 70       .p             // Y=value of function key status
-    lda #osbyte_read_write_f0_ff_status                               // 2de7: a9 e0       ..
+    lda #osbyte_read_write_characters_f0_ff_status                    // 2de7: a9 e0       ..
     ldx #0                                                            // 2de9: a2 00       ..
     ldy #$ff                                                          // 2deb: a0 ff       ..
     jsr osbyte                                                        // 2ded: 20 f4 ff     ..            // Read character status flag ($f0-$ff)
@@ -4016,13 +4016,13 @@ buffer_empty
     sty mem                                                           // 2e74: 84 70       .p             // Y=value of ESCAPE effects
 
     // *************** Test OSBYTE 0xe6 ***************
-    lda #osbyte_read_write_escape_flags                               // 2e76: a9 e6       ..
+    lda #osbyte_read_write_escape_effects                             // 2e76: a9 e6       ..
     ldx #$2a // '*'                                                   // 2e78: a2 2a       .*
     ldy #0                                                            // 2e7a: a0 00       ..
     jsr osbyte                                                        // 2e7c: 20 f4 ff     ..            // Write ESCAPE effects, value X=42
     stx mem                                                           // 2e7f: 86 70       .p             // X=old value of ESCAPE effects
     sty mem                                                           // 2e81: 84 70       .p             // Y=value of User 6522 IRQ bit mask
-    lda #osbyte_read_write_escape_flags                               // 2e83: a9 e6       ..
+    lda #osbyte_read_write_escape_effects                             // 2e83: a9 e6       ..
     ldx #0                                                            // 2e85: a2 00       ..
     ldy #$ff                                                          // 2e87: a0 ff       ..
     jsr osbyte                                                        // 2e89: 20 f4 ff     ..            // Read ESCAPE effects
@@ -4226,13 +4226,13 @@ buffer_empty
     sty mem                                                           // 2ffa: 84 70       .p             // Y=value of printer destination
 
     // *************** Test OSBYTE 0xf5 ***************
-    lda #osbyte_read_write_printer_destination_flag                   // 2ffc: a9 f5       ..
+    lda #osbyte_read_write_printer_destination                        // 2ffc: a9 f5       ..
     ldx #$2a // '*'                                                   // 2ffe: a2 2a       .*
     ldy #0                                                            // 3000: a0 00       ..
     jsr osbyte                                                        // 3002: 20 f4 ff     ..            // Write printer destination, value X=42
     stx mem                                                           // 3005: 86 70       .p             // X=old value of printer destination
     sty mem                                                           // 3007: 84 70       .p             // Y=value of printer ignore character
-    lda #osbyte_read_write_printer_destination_flag                   // 3009: a9 f5       ..
+    lda #osbyte_read_write_printer_destination                        // 3009: a9 f5       ..
     ldx #0                                                            // 300b: a2 00       ..
     ldy #$ff                                                          // 300d: a0 ff       ..
     jsr osbyte                                                        // 300f: 20 f4 ff     ..            // Read printer destination
@@ -4367,7 +4367,7 @@ buffer_empty
 
     // *************** Test OSBYTE 0xff ***************
     lda #osbyte_read_write_startup_options                            // 3100: a9 ff       ..
-    ldx #$2a // '*'                                                   // 3102: a2 2a       .*
+    ldx #%00101010                                                    // 3102: a2 2a       .*
     ldy #0                                                            // 3104: a0 00       ..
     jsr osbyte                                                        // 3106: 20 f4 ff     ..            // Write start-up option byte, value X=42
 

--- a/examples/known_good/anfs418_acme.asm
+++ b/examples/known_good/anfs418_acme.asm
@@ -1,4 +1,5 @@
 ; Constants
+inkey_key_ctrl                                  = 254
 osbyte_acknowledge_escape                       = 126
 osbyte_close_spool_exec                         = 119
 osbyte_explode_chars                            = 20
@@ -13,6 +14,8 @@ osbyte_scan_keyboard_from_16                    = 122
 osbyte_vsync                                    = 19
 osbyte_write_keys_pressed                       = 120
 osfile_read_catalogue_info                      = 5
+osfind_close                                    = 0
+osfind_open_input                               = 64
 osword_read_palette                             = 11
 service_claim_absolute_workspace                = 1
 service_vectors_changed                         = 15
@@ -3147,7 +3150,7 @@ c9722
     jsr sub_c8e8c                                                     ; 9722: 20 8c 8e     ..
     pla                                                               ; 9725: 68          h
     tay                                                               ; 9726: a8          .
-    lda #0                                                            ; 9727: a9 00       ..
+    lda #osfind_close                                                 ; 9727: a9 00       ..
     jsr osfind                                                        ; 9729: 20 ce ff     ..            ; Close one or all files
 ; $972c referenced 1 time by $9717
 c972c
@@ -4766,7 +4769,7 @@ ca3b4
     plp                                                               ; a3c1: 28          (
     bne ca3e3                                                         ; a3c2: d0 1f       ..
     lda #osbyte_scan_keyboard                                         ; a3c4: a9 79       .y
-    ldx #$81                                                          ; a3c6: a2 81       ..
+    ldx #(255 - inkey_key_ctrl) XOR 128                               ; a3c6: a2 81       ..             ; X=internal key number EOR 128
     jsr osbyte                                                        ; a3c8: 20 f4 ff     ..            ; Test for 'CTRL' key pressed (X=129)
     txa                                                               ; a3cb: 8a          .              ; X has top bit set if 'CTRL' pressed
     bpl ca3e3                                                         ; a3cc: 10 15       ..
@@ -7435,7 +7438,7 @@ sub_cb98f
     rts                                                               ; b993: 60          `
 
 sub_cb994
-    lda #0                                                            ; b994: a9 00       ..
+    lda #osfind_close                                                 ; b994: a9 00       ..
     tay                                                               ; b996: a8          .
     jmp osfind                                                        ; b997: 4c ce ff    L..            ; Close all files (Y=0)
 
@@ -7923,7 +7926,7 @@ loop_cbc34
 ; $bc3d referenced 6 times by $b9b0, $ba04, $ba57, $bb68, $bba2, $bc0f
 cbc3d
     ldy l00a8                                                         ; bc3d: a4 a8       ..
-    lda #0                                                            ; bc3f: a9 00       ..
+    lda #osfind_close                                                 ; bc3f: a9 00       ..
     jmp osfind                                                        ; bc41: 4c ce ff    L..            ; Close one or all files
 
 ; $bc44 referenced 2 times by $b9a0, $ba1b
@@ -7938,7 +7941,7 @@ sub_cbc44
     adc l00f3                                                         ; bc4d: 65 f3       e.
     pha                                                               ; bc4f: 48          H
     tay                                                               ; bc50: a8          .
-    lda #$40 ; '@'                                                    ; bc51: a9 40       .@
+    lda #osfind_open_input                                            ; bc51: a9 40       .@
     jsr osfind                                                        ; bc53: 20 ce ff     ..            ; Open file for input (A=64)
     tay                                                               ; bc56: a8          .              ; A=file handle (or zero on failure)
     sta l00a8                                                         ; bc57: 85 a8       ..
@@ -10542,6 +10545,9 @@ pydis_end
 ;     sub_cbc8c
 ;     sub_cbf18
 ;     sub_cbf25
+!if ((255 - inkey_key_ctrl) XOR 128) != $81 {
+    !error "Assertion failed: (255 - inkey_key_ctrl) XOR 128 == $81"
+}
 !if (<((c86e3)-1)) != $e2 {
     !error "Assertion failed: <((c86e3)-1) == $e2"
 }
@@ -10835,6 +10841,12 @@ pydis_end
 }
 !if (osfile_read_catalogue_info) != $05 {
     !error "Assertion failed: osfile_read_catalogue_info == $05"
+}
+!if (osfind_close) != $00 {
+    !error "Assertion failed: osfind_close == $00"
+}
+!if (osfind_open_input) != $40 {
+    !error "Assertion failed: osfind_open_input == $40"
 }
 !if (osword_read_palette) != $0b {
     !error "Assertion failed: osword_read_palette == $0b"

--- a/examples/known_good/anfs418_acme.asm
+++ b/examples/known_good/anfs418_acme.asm
@@ -1368,7 +1368,7 @@ c8b98
     bvc c8bab                                                         ; 8ba6: 50 03       P.
 ; $8ba8 referenced 1 time by $8b98
 c8ba8
-    jsr osnewl                                                        ; 8ba8: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; 8ba8: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
 ; $8bab referenced 2 times by $8ba6, $8c6d
 c8bab
     tya                                                               ; 8bab: 98          .
@@ -1464,7 +1464,7 @@ c8c24
     tax                                                               ; 8c25: aa          .
 ; $8c26 referenced 1 time by $8be4
 c8c26
-    jsr osnewl                                                        ; 8c26: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; 8c26: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     inx                                                               ; 8c29: e8          .
     inx                                                               ; 8c2a: e8          .
     inx                                                               ; 8c2b: e8          .
@@ -1485,7 +1485,7 @@ sub_c8c33
     beq c8c4d                                                         ; 8c3a: f0 11       ..
     tya                                                               ; 8c3c: 98          .
     pha                                                               ; 8c3d: 48          H
-    jsr osnewl                                                        ; 8c3e: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; 8c3e: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     ldy #$0b                                                          ; 8c41: a0 0b       ..
     lda #$20 ; ' '                                                    ; 8c43: a9 20       .
 ; $8c45 referenced 1 time by $8c49
@@ -1597,7 +1597,7 @@ c8cda
 c8ce0
     jsr sub_c8b1a                                                     ; 8ce0: 20 1a 8b     ..
     jsr c8ff1                                                         ; 8ce3: 20 f1 8f     ..
-    jsr osnewl                                                        ; 8ce6: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; 8ce6: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     ldx l00a8                                                         ; 8ce9: a6 a8       ..
     bne c8cc9                                                         ; 8ceb: d0 dc       ..
     lda l1071                                                         ; 8ced: ad 71 10    .q.
@@ -1747,7 +1747,7 @@ c8deb
     iny                                                               ; 8df2: c8          .
     cmp #$0d                                                          ; 8df3: c9 0d       ..
     bne c8dd2                                                         ; 8df5: d0 db       ..
-    jsr osnewl                                                        ; 8df7: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; 8df7: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
 ; $8dfa referenced 1 time by $8dc7
 c8dfa
     tya                                                               ; 8dfa: 98          .
@@ -2091,7 +2091,7 @@ c8ff1
     nop                                                               ; 901d: ea          .
 ; $901e referenced 1 time by $900f
 c901e
-    jsr osnewl                                                        ; 901e: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; 901e: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     rts                                                               ; 9021: 60          `
 
 ; $9022 referenced 1 time by $8be1
@@ -3629,7 +3629,7 @@ loop_c9a40
     ldy #5                                                            ; 9a49: a0 05       ..
     jsr sub_c9a62                                                     ; 9a4b: 20 62 9a     b.
     jsr sub_c9a57                                                     ; 9a4e: 20 57 9a     W.
-    jsr osnewl                                                        ; 9a51: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; 9a51: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     jmp c9cc7                                                         ; 9a54: 4c c7 9c    L..
 
 ; $9a57 referenced 1 time by $9a4e
@@ -4218,7 +4218,7 @@ ca09b
 sub_ca09e
     bit l9491                                                         ; a09e: 2c 91 94    ,..
     jsr sub_cb198                                                     ; a0a1: 20 98 b1     ..
-    jmp osnewl                                                        ; a0a4: 4c e7 ff    L..            ; Write newline (character 10)
+    jmp osnewl                                                        ; a0a4: 4c e7 ff    L..            ; Write newline (characters 10 and 13)
 
 ; $a0a7 referenced 3 times by $a08b, $b011, $b1e8
 sub_ca0a7
@@ -5697,7 +5697,7 @@ cae27
 
     ldx #$1b                                                          ; ae43: a2 1b       ..
     jsr sub_cae82                                                     ; ae45: 20 82 ae     ..
-    jsr osnewl                                                        ; ae48: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; ae48: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     pla                                                               ; ae4b: 68          h
     sta l1071                                                         ; ae4c: 8d 71 10    .q.
 ; $ae4f referenced 1 time by $ae80
@@ -5742,7 +5742,7 @@ cae84
 
 ; $ae8f referenced 1 time by $ae6c
 cae8f
-    jmp osnewl                                                        ; ae8f: 4c e7 ff    L..            ; Write newline (character 10)
+    jmp osnewl                                                        ; ae8f: 4c e7 ff    L..            ; Write newline (characters 10 and 13)
 
 ; $ae92 referenced 1 time by $a1c7
 sub_cae92
@@ -6501,7 +6501,7 @@ cb2ac
     jsr sub_cb198                                                     ; b2d1: 20 98 b1     ..
 ; $b2d4 referenced 3 times by $b29a, $b2aa, $b2bd
 cb2d4
-    jsr osnewl                                                        ; b2d4: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; b2d4: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
 ; $b2d7 referenced 1 time by $b26e
 cb2d7
     pla                                                               ; b2d7: 68          h
@@ -6724,7 +6724,7 @@ cb40e
     dec l00b5                                                         ; b41b: c6 b5       ..
 ; $b41d referenced 1 time by $b3f1
 cb41d
-    jsr osnewl                                                        ; b41d: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; b41d: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     jmp cb3a3                                                         ; b420: 4c a3 b3    L..
 
 ; $b423 referenced 1 time by $b3fd
@@ -7460,7 +7460,7 @@ cb9aa
     bcc cb9b6                                                         ; b9ad: 90 07       ..
     plp                                                               ; b9af: 28          (
     jsr cbc3d                                                         ; b9b0: 20 3d bc     =.
-    jmp osnewl                                                        ; b9b3: 4c e7 ff    L..            ; Write newline (character 10)
+    jmp osnewl                                                        ; b9b3: 4c e7 ff    L..            ; Write newline (characters 10 and 13)
 
 ; $b9b6 referenced 1 time by $b9ad
 cb9b6
@@ -7500,7 +7500,7 @@ cb9da
     sta l00ad                                                         ; b9e5: 85 ad       ..
 ; $b9e7 referenced 2 times by $b9f2, $b9f7
 cb9e7
-    jsr osnewl                                                        ; b9e7: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; b9e7: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     jmp cb9aa                                                         ; b9ea: 4c aa b9    L..
 
 ; $b9ed referenced 1 time by $b9de
@@ -7528,7 +7528,7 @@ sub_cb9ff
 ; $ba04 referenced 1 time by $ba01
 cba04
     jsr cbc3d                                                         ; ba04: 20 3d bc     =.
-    jsr osnewl                                                        ; ba07: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; ba07: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     lda #osbyte_acknowledge_escape                                    ; ba0a: a9 7e       .~
     jsr osbyte                                                        ; ba0c: 20 f4 ff     ..            ; Clear escape condition and perform escape effects
     lda #$11                                                          ; ba0f: a9 11       ..
@@ -7668,7 +7668,7 @@ cbac0
     bpl loop_cbab6                                                    ; bacd: 10 e7       ..
 ; $bacf referenced 1 time by $baca
 cbacf
-    jsr osnewl                                                        ; bacf: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; bacf: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     plp                                                               ; bad2: 28          (
     bcs cbad8                                                         ; bad3: b0 03       ..
     jmp cba33                                                         ; bad5: 4c 33 ba    L3.
@@ -7695,8 +7695,8 @@ loop_cbaf2
     and #$0f                                                          ; baf8: 29 0f       ).
     dex                                                               ; bafa: ca          .
     bpl loop_cbaf2                                                    ; bafb: 10 f5       ..
-    jsr osnewl                                                        ; bafd: 20 e7 ff     ..            ; Write newline (character 10)
-    jmp osnewl                                                        ; bb00: 4c e7 ff    L..            ; Write newline (character 10)
+    jsr osnewl                                                        ; bafd: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
+    jmp osnewl                                                        ; bb00: 4c e7 ff    L..            ; Write newline (characters 10 and 13)
 
 ; $bb03 referenced 2 times by $ba92, $baf2
 sub_cbb03

--- a/examples/known_good/anfs418_beebasm.asm
+++ b/examples/known_good/anfs418_beebasm.asm
@@ -1,4 +1,5 @@
 ; Constants
+inkey_key_ctrl                                  = 254
 osbyte_acknowledge_escape                       = 126
 osbyte_close_spool_exec                         = 119
 osbyte_explode_chars                            = 20
@@ -13,6 +14,8 @@ osbyte_scan_keyboard_from_16                    = 122
 osbyte_vsync                                    = 19
 osbyte_write_keys_pressed                       = 120
 osfile_read_catalogue_info                      = 5
+osfind_close                                    = 0
+osfind_open_input                               = 64
 osword_read_palette                             = 11
 service_claim_absolute_workspace                = 1
 service_vectors_changed                         = 15
@@ -3148,7 +3151,7 @@ error_template_minus_1 = sub_c96b3+1
     jsr sub_c8e8c                                                     ; 9722: 20 8c 8e     ..
     pla                                                               ; 9725: 68          h
     tay                                                               ; 9726: a8          .
-    lda #0                                                            ; 9727: a9 00       ..
+    lda #osfind_close                                                 ; 9727: a9 00       ..
     jsr osfind                                                        ; 9729: 20 ce ff     ..            ; Close one or all files
 ; &972c referenced 1 time by &9717
 .c972c
@@ -4767,7 +4770,7 @@ error_template_minus_1 = sub_c96b3+1
     plp                                                               ; a3c1: 28          (
     bne ca3e3                                                         ; a3c2: d0 1f       ..
     lda #osbyte_scan_keyboard                                         ; a3c4: a9 79       .y
-    ldx #&81                                                          ; a3c6: a2 81       ..
+    ldx #(255 - inkey_key_ctrl) EOR 128                               ; a3c6: a2 81       ..             ; X=internal key number EOR 128
     jsr osbyte                                                        ; a3c8: 20 f4 ff     ..            ; Test for 'CTRL' key pressed (X=129)
     txa                                                               ; a3cb: 8a          .              ; X has top bit set if 'CTRL' pressed
     bpl ca3e3                                                         ; a3cc: 10 15       ..
@@ -7436,7 +7439,7 @@ lb487 = sub_cb485+2
     rts                                                               ; b993: 60          `
 
 .sub_cb994
-    lda #0                                                            ; b994: a9 00       ..
+    lda #osfind_close                                                 ; b994: a9 00       ..
     tay                                                               ; b996: a8          .
     jmp osfind                                                        ; b997: 4c ce ff    L..            ; Close all files (Y=0)
 
@@ -7924,7 +7927,7 @@ lb487 = sub_cb485+2
 ; &bc3d referenced 6 times by &b9b0, &ba04, &ba57, &bb68, &bba2, &bc0f
 .cbc3d
     ldy l00a8                                                         ; bc3d: a4 a8       ..
-    lda #0                                                            ; bc3f: a9 00       ..
+    lda #osfind_close                                                 ; bc3f: a9 00       ..
     jmp osfind                                                        ; bc41: 4c ce ff    L..            ; Close one or all files
 
 ; &bc44 referenced 2 times by &b9a0, &ba1b
@@ -7939,7 +7942,7 @@ lb487 = sub_cb485+2
     adc l00f3                                                         ; bc4d: 65 f3       e.
     pha                                                               ; bc4f: 48          H
     tay                                                               ; bc50: a8          .
-    lda #&40 ; '@'                                                    ; bc51: a9 40       .@
+    lda #osfind_open_input                                            ; bc51: a9 40       .@
     jsr osfind                                                        ; bc53: 20 ce ff     ..            ; Open file for input (A=64)
     tay                                                               ; bc56: a8          .              ; A=file handle (or zero on failure)
     sta l00a8                                                         ; bc57: 85 a8       ..
@@ -10546,6 +10549,7 @@ lb487 = sub_cb485+2
 ;     sub_cbc8c
 ;     sub_cbf18
 ;     sub_cbf25
+    assert (255 - inkey_key_ctrl) EOR 128 == &81
     assert <((c86e3)-1) == &e2
     assert <((sub_c8689)-1) == &88
     assert <((sub_c868d)-1) == &8c
@@ -10644,6 +10648,8 @@ lb487 = sub_cb485+2
     assert osbyte_vsync == &13
     assert osbyte_write_keys_pressed == &78
     assert osfile_read_catalogue_info == &05
+    assert osfind_close == &00
+    assert osfind_open_input == &40
     assert osword_read_palette == &0b
     assert service_claim_absolute_workspace == &01
     assert service_vectors_changed == &0f

--- a/examples/known_good/anfs418_beebasm.asm
+++ b/examples/known_good/anfs418_beebasm.asm
@@ -1369,7 +1369,7 @@ l89a6 = c89a4+2
     bvc c8bab                                                         ; 8ba6: 50 03       P.
 ; &8ba8 referenced 1 time by &8b98
 .c8ba8
-    jsr osnewl                                                        ; 8ba8: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; 8ba8: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
 ; &8bab referenced 2 times by &8ba6, &8c6d
 .c8bab
     tya                                                               ; 8bab: 98          .
@@ -1465,7 +1465,7 @@ l89a6 = c89a4+2
     tax                                                               ; 8c25: aa          .
 ; &8c26 referenced 1 time by &8be4
 .c8c26
-    jsr osnewl                                                        ; 8c26: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; 8c26: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     inx                                                               ; 8c29: e8          .
     inx                                                               ; 8c2a: e8          .
     inx                                                               ; 8c2b: e8          .
@@ -1486,7 +1486,7 @@ l89a6 = c89a4+2
     beq c8c4d                                                         ; 8c3a: f0 11       ..
     tya                                                               ; 8c3c: 98          .
     pha                                                               ; 8c3d: 48          H
-    jsr osnewl                                                        ; 8c3e: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; 8c3e: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     ldy #&0b                                                          ; 8c41: a0 0b       ..
     lda #&20 ; ' '                                                    ; 8c43: a9 20       .
 ; &8c45 referenced 1 time by &8c49
@@ -1598,7 +1598,7 @@ l89a6 = c89a4+2
 .c8ce0
     jsr sub_c8b1a                                                     ; 8ce0: 20 1a 8b     ..
     jsr c8ff1                                                         ; 8ce3: 20 f1 8f     ..
-    jsr osnewl                                                        ; 8ce6: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; 8ce6: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     ldx l00a8                                                         ; 8ce9: a6 a8       ..
     bne c8cc9                                                         ; 8ceb: d0 dc       ..
     lda l1071                                                         ; 8ced: ad 71 10    .q.
@@ -1748,7 +1748,7 @@ l89a6 = c89a4+2
     iny                                                               ; 8df2: c8          .
     cmp #&0d                                                          ; 8df3: c9 0d       ..
     bne c8dd2                                                         ; 8df5: d0 db       ..
-    jsr osnewl                                                        ; 8df7: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; 8df7: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
 ; &8dfa referenced 1 time by &8dc7
 .c8dfa
     tya                                                               ; 8dfa: 98          .
@@ -2092,7 +2092,7 @@ l8f48 = loop_c8f46+2
     nop                                                               ; 901d: ea          .
 ; &901e referenced 1 time by &900f
 .c901e
-    jsr osnewl                                                        ; 901e: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; 901e: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     rts                                                               ; 9021: 60          `
 
 ; &9022 referenced 1 time by &8be1
@@ -3630,7 +3630,7 @@ error_template_minus_1 = sub_c96b3+1
     ldy #5                                                            ; 9a49: a0 05       ..
     jsr sub_c9a62                                                     ; 9a4b: 20 62 9a     b.
     jsr sub_c9a57                                                     ; 9a4e: 20 57 9a     W.
-    jsr osnewl                                                        ; 9a51: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; 9a51: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     jmp c9cc7                                                         ; 9a54: 4c c7 9c    L..
 
 ; &9a57 referenced 1 time by &9a4e
@@ -4219,7 +4219,7 @@ error_template_minus_1 = sub_c96b3+1
 .sub_ca09e
     bit l9491                                                         ; a09e: 2c 91 94    ,..
     jsr sub_cb198                                                     ; a0a1: 20 98 b1     ..
-    jmp osnewl                                                        ; a0a4: 4c e7 ff    L..            ; Write newline (character 10)
+    jmp osnewl                                                        ; a0a4: 4c e7 ff    L..            ; Write newline (characters 10 and 13)
 
 ; &a0a7 referenced 3 times by &a08b, &b011, &b1e8
 .sub_ca0a7
@@ -5698,7 +5698,7 @@ lad43 = sub_cad41+2
 
     ldx #&1b                                                          ; ae43: a2 1b       ..
     jsr sub_cae82                                                     ; ae45: 20 82 ae     ..
-    jsr osnewl                                                        ; ae48: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; ae48: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     pla                                                               ; ae4b: 68          h
     sta l1071                                                         ; ae4c: 8d 71 10    .q.
 ; &ae4f referenced 1 time by &ae80
@@ -5743,7 +5743,7 @@ lad43 = sub_cad41+2
 
 ; &ae8f referenced 1 time by &ae6c
 .cae8f
-    jmp osnewl                                                        ; ae8f: 4c e7 ff    L..            ; Write newline (character 10)
+    jmp osnewl                                                        ; ae8f: 4c e7 ff    L..            ; Write newline (characters 10 and 13)
 
 ; &ae92 referenced 1 time by &a1c7
 .sub_cae92
@@ -6502,7 +6502,7 @@ lb13f = sub_cb13e+1
     jsr sub_cb198                                                     ; b2d1: 20 98 b1     ..
 ; &b2d4 referenced 3 times by &b29a, &b2aa, &b2bd
 .cb2d4
-    jsr osnewl                                                        ; b2d4: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; b2d4: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
 ; &b2d7 referenced 1 time by &b26e
 .cb2d7
     pla                                                               ; b2d7: 68          h
@@ -6725,7 +6725,7 @@ lb13f = sub_cb13e+1
     dec l00b5                                                         ; b41b: c6 b5       ..
 ; &b41d referenced 1 time by &b3f1
 .cb41d
-    jsr osnewl                                                        ; b41d: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; b41d: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     jmp cb3a3                                                         ; b420: 4c a3 b3    L..
 
 ; &b423 referenced 1 time by &b3fd
@@ -7461,7 +7461,7 @@ lb487 = sub_cb485+2
     bcc cb9b6                                                         ; b9ad: 90 07       ..
     plp                                                               ; b9af: 28          (
     jsr cbc3d                                                         ; b9b0: 20 3d bc     =.
-    jmp osnewl                                                        ; b9b3: 4c e7 ff    L..            ; Write newline (character 10)
+    jmp osnewl                                                        ; b9b3: 4c e7 ff    L..            ; Write newline (characters 10 and 13)
 
 ; &b9b6 referenced 1 time by &b9ad
 .cb9b6
@@ -7501,7 +7501,7 @@ lb487 = sub_cb485+2
     sta l00ad                                                         ; b9e5: 85 ad       ..
 ; &b9e7 referenced 2 times by &b9f2, &b9f7
 .cb9e7
-    jsr osnewl                                                        ; b9e7: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; b9e7: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     jmp cb9aa                                                         ; b9ea: 4c aa b9    L..
 
 ; &b9ed referenced 1 time by &b9de
@@ -7529,7 +7529,7 @@ lb487 = sub_cb485+2
 ; &ba04 referenced 1 time by &ba01
 .cba04
     jsr cbc3d                                                         ; ba04: 20 3d bc     =.
-    jsr osnewl                                                        ; ba07: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; ba07: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     lda #osbyte_acknowledge_escape                                    ; ba0a: a9 7e       .~
     jsr osbyte                                                        ; ba0c: 20 f4 ff     ..            ; Clear escape condition and perform escape effects
     lda #&11                                                          ; ba0f: a9 11       ..
@@ -7669,7 +7669,7 @@ lb487 = sub_cb485+2
     bpl loop_cbab6                                                    ; bacd: 10 e7       ..
 ; &bacf referenced 1 time by &baca
 .cbacf
-    jsr osnewl                                                        ; bacf: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; bacf: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     plp                                                               ; bad2: 28          (
     bcs cbad8                                                         ; bad3: b0 03       ..
     jmp cba33                                                         ; bad5: 4c 33 ba    L3.
@@ -7696,8 +7696,8 @@ lb487 = sub_cb485+2
     and #&0f                                                          ; baf8: 29 0f       ).
     dex                                                               ; bafa: ca          .
     bpl loop_cbaf2                                                    ; bafb: 10 f5       ..
-    jsr osnewl                                                        ; bafd: 20 e7 ff     ..            ; Write newline (character 10)
-    jmp osnewl                                                        ; bb00: 4c e7 ff    L..            ; Write newline (character 10)
+    jsr osnewl                                                        ; bafd: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
+    jmp osnewl                                                        ; bb00: 4c e7 ff    L..            ; Write newline (characters 10 and 13)
 
 ; &bb03 referenced 2 times by &ba92, &baf2
 .sub_cbb03

--- a/examples/known_good/anfs418_xa.asm
+++ b/examples/known_good/anfs418_xa.asm
@@ -1,4 +1,5 @@
 // Constants
+inkey_key_ctrl                                  = 254
 osbyte_acknowledge_escape                       = 126
 osbyte_close_spool_exec                         = 119
 osbyte_explode_chars                            = 20
@@ -13,6 +14,8 @@ osbyte_scan_keyboard_from_16                    = 122
 osbyte_vsync                                    = 19
 osbyte_write_keys_pressed                       = 120
 osfile_read_catalogue_info                      = 5
+osfind_close                                    = 0
+osfind_open_input                               = 64
 osword_read_palette                             = 11
 service_claim_absolute_workspace                = 1
 service_vectors_changed                         = 15
@@ -3147,7 +3150,7 @@ c9722
     jsr sub_c8e8c                                                     // 9722: 20 8c 8e     ..
     pla                                                               // 9725: 68          h
     tay                                                               // 9726: a8          .
-    lda #0                                                            // 9727: a9 00       ..
+    lda #osfind_close                                                 // 9727: a9 00       ..
     jsr osfind                                                        // 9729: 20 ce ff     ..            // Close one or all files
 // $972c referenced 1 time by $9717
 c972c
@@ -4766,7 +4769,7 @@ ca3b4
     plp                                                               // a3c1: 28          (
     bne ca3e3                                                         // a3c2: d0 1f       ..
     lda #osbyte_scan_keyboard                                         // a3c4: a9 79       .y
-    ldx #$81                                                          // a3c6: a2 81       ..
+    ldx #(255 - inkey_key_ctrl) ^ 128                                 // a3c6: a2 81       ..             // X=internal key number EOR 128
     jsr osbyte                                                        // a3c8: 20 f4 ff     ..            // Test for 'CTRL' key pressed (X=129)
     txa                                                               // a3cb: 8a          .              // X has top bit set if 'CTRL' pressed
     bpl ca3e3                                                         // a3cc: 10 15       ..
@@ -7435,7 +7438,7 @@ sub_cb98f
     rts                                                               // b993: 60          `
 
 sub_cb994
-    lda #0                                                            // b994: a9 00       ..
+    lda #osfind_close                                                 // b994: a9 00       ..
     tay                                                               // b996: a8          .
     jmp osfind                                                        // b997: 4c ce ff    L..            // Close all files (Y=0)
 
@@ -7923,7 +7926,7 @@ loop_cbc34
 // $bc3d referenced 6 times by $b9b0, $ba04, $ba57, $bb68, $bba2, $bc0f
 cbc3d
     ldy l00a8                                                         // bc3d: a4 a8       ..
-    lda #0                                                            // bc3f: a9 00       ..
+    lda #osfind_close                                                 // bc3f: a9 00       ..
     jmp osfind                                                        // bc41: 4c ce ff    L..            // Close one or all files
 
 // $bc44 referenced 2 times by $b9a0, $ba1b
@@ -7938,7 +7941,7 @@ sub_cbc44
     adc l00f3                                                         // bc4d: 65 f3       e.
     pha                                                               // bc4f: 48          H
     tay                                                               // bc50: a8          .
-    lda #$40 // '@'                                                   // bc51: a9 40       .@
+    lda #osfind_open_input                                            // bc51: a9 40       .@
     jsr osfind                                                        // bc53: 20 ce ff     ..            // Open file for input (A=64)
     tay                                                               // bc56: a8          .              // A=file handle (or zero on failure)
     sta l00a8                                                         // bc57: 85 a8       ..

--- a/examples/known_good/anfs418_xa.asm
+++ b/examples/known_good/anfs418_xa.asm
@@ -1368,7 +1368,7 @@ c8b98
     bvc c8bab                                                         // 8ba6: 50 03       P.
 // $8ba8 referenced 1 time by $8b98
 c8ba8
-    jsr osnewl                                                        // 8ba8: 20 e7 ff     ..            // Write newline (character 10)
+    jsr osnewl                                                        // 8ba8: 20 e7 ff     ..            // Write newline (characters 10 and 13)
 // $8bab referenced 2 times by $8ba6, $8c6d
 c8bab
     tya                                                               // 8bab: 98          .
@@ -1464,7 +1464,7 @@ c8c24
     tax                                                               // 8c25: aa          .
 // $8c26 referenced 1 time by $8be4
 c8c26
-    jsr osnewl                                                        // 8c26: 20 e7 ff     ..            // Write newline (character 10)
+    jsr osnewl                                                        // 8c26: 20 e7 ff     ..            // Write newline (characters 10 and 13)
     inx                                                               // 8c29: e8          .
     inx                                                               // 8c2a: e8          .
     inx                                                               // 8c2b: e8          .
@@ -1485,7 +1485,7 @@ sub_c8c33
     beq c8c4d                                                         // 8c3a: f0 11       ..
     tya                                                               // 8c3c: 98          .
     pha                                                               // 8c3d: 48          H
-    jsr osnewl                                                        // 8c3e: 20 e7 ff     ..            // Write newline (character 10)
+    jsr osnewl                                                        // 8c3e: 20 e7 ff     ..            // Write newline (characters 10 and 13)
     ldy #$0b                                                          // 8c41: a0 0b       ..
     lda #$20 // ' '                                                   // 8c43: a9 20       .
 // $8c45 referenced 1 time by $8c49
@@ -1597,7 +1597,7 @@ c8cda
 c8ce0
     jsr sub_c8b1a                                                     // 8ce0: 20 1a 8b     ..
     jsr c8ff1                                                         // 8ce3: 20 f1 8f     ..
-    jsr osnewl                                                        // 8ce6: 20 e7 ff     ..            // Write newline (character 10)
+    jsr osnewl                                                        // 8ce6: 20 e7 ff     ..            // Write newline (characters 10 and 13)
     ldx l00a8                                                         // 8ce9: a6 a8       ..
     bne c8cc9                                                         // 8ceb: d0 dc       ..
     lda l1071                                                         // 8ced: ad 71 10    .q.
@@ -1747,7 +1747,7 @@ c8deb
     iny                                                               // 8df2: c8          .
     cmp #$0d                                                          // 8df3: c9 0d       ..
     bne c8dd2                                                         // 8df5: d0 db       ..
-    jsr osnewl                                                        // 8df7: 20 e7 ff     ..            // Write newline (character 10)
+    jsr osnewl                                                        // 8df7: 20 e7 ff     ..            // Write newline (characters 10 and 13)
 // $8dfa referenced 1 time by $8dc7
 c8dfa
     tya                                                               // 8dfa: 98          .
@@ -2091,7 +2091,7 @@ c8ff1
     nop                                                               // 901d: ea          .
 // $901e referenced 1 time by $900f
 c901e
-    jsr osnewl                                                        // 901e: 20 e7 ff     ..            // Write newline (character 10)
+    jsr osnewl                                                        // 901e: 20 e7 ff     ..            // Write newline (characters 10 and 13)
     rts                                                               // 9021: 60          `
 
 // $9022 referenced 1 time by $8be1
@@ -3629,7 +3629,7 @@ loop_c9a40
     ldy #5                                                            // 9a49: a0 05       ..
     jsr sub_c9a62                                                     // 9a4b: 20 62 9a     b.
     jsr sub_c9a57                                                     // 9a4e: 20 57 9a     W.
-    jsr osnewl                                                        // 9a51: 20 e7 ff     ..            // Write newline (character 10)
+    jsr osnewl                                                        // 9a51: 20 e7 ff     ..            // Write newline (characters 10 and 13)
     jmp c9cc7                                                         // 9a54: 4c c7 9c    L..
 
 // $9a57 referenced 1 time by $9a4e
@@ -4218,7 +4218,7 @@ ca09b
 sub_ca09e
     bit l9491                                                         // a09e: 2c 91 94    ,..
     jsr sub_cb198                                                     // a0a1: 20 98 b1     ..
-    jmp osnewl                                                        // a0a4: 4c e7 ff    L..            // Write newline (character 10)
+    jmp osnewl                                                        // a0a4: 4c e7 ff    L..            // Write newline (characters 10 and 13)
 
 // $a0a7 referenced 3 times by $a08b, $b011, $b1e8
 sub_ca0a7
@@ -5697,7 +5697,7 @@ cae27
 
     ldx #$1b                                                          // ae43: a2 1b       ..
     jsr sub_cae82                                                     // ae45: 20 82 ae     ..
-    jsr osnewl                                                        // ae48: 20 e7 ff     ..            // Write newline (character 10)
+    jsr osnewl                                                        // ae48: 20 e7 ff     ..            // Write newline (characters 10 and 13)
     pla                                                               // ae4b: 68          h
     sta l1071                                                         // ae4c: 8d 71 10    .q.
 // $ae4f referenced 1 time by $ae80
@@ -5742,7 +5742,7 @@ cae84
 
 // $ae8f referenced 1 time by $ae6c
 cae8f
-    jmp osnewl                                                        // ae8f: 4c e7 ff    L..            // Write newline (character 10)
+    jmp osnewl                                                        // ae8f: 4c e7 ff    L..            // Write newline (characters 10 and 13)
 
 // $ae92 referenced 1 time by $a1c7
 sub_cae92
@@ -6501,7 +6501,7 @@ cb2ac
     jsr sub_cb198                                                     // b2d1: 20 98 b1     ..
 // $b2d4 referenced 3 times by $b29a, $b2aa, $b2bd
 cb2d4
-    jsr osnewl                                                        // b2d4: 20 e7 ff     ..            // Write newline (character 10)
+    jsr osnewl                                                        // b2d4: 20 e7 ff     ..            // Write newline (characters 10 and 13)
 // $b2d7 referenced 1 time by $b26e
 cb2d7
     pla                                                               // b2d7: 68          h
@@ -6724,7 +6724,7 @@ cb40e
     dec l00b5                                                         // b41b: c6 b5       ..
 // $b41d referenced 1 time by $b3f1
 cb41d
-    jsr osnewl                                                        // b41d: 20 e7 ff     ..            // Write newline (character 10)
+    jsr osnewl                                                        // b41d: 20 e7 ff     ..            // Write newline (characters 10 and 13)
     jmp cb3a3                                                         // b420: 4c a3 b3    L..
 
 // $b423 referenced 1 time by $b3fd
@@ -7460,7 +7460,7 @@ cb9aa
     bcc cb9b6                                                         // b9ad: 90 07       ..
     plp                                                               // b9af: 28          (
     jsr cbc3d                                                         // b9b0: 20 3d bc     =.
-    jmp osnewl                                                        // b9b3: 4c e7 ff    L..            // Write newline (character 10)
+    jmp osnewl                                                        // b9b3: 4c e7 ff    L..            // Write newline (characters 10 and 13)
 
 // $b9b6 referenced 1 time by $b9ad
 cb9b6
@@ -7500,7 +7500,7 @@ cb9da
     sta l00ad                                                         // b9e5: 85 ad       ..
 // $b9e7 referenced 2 times by $b9f2, $b9f7
 cb9e7
-    jsr osnewl                                                        // b9e7: 20 e7 ff     ..            // Write newline (character 10)
+    jsr osnewl                                                        // b9e7: 20 e7 ff     ..            // Write newline (characters 10 and 13)
     jmp cb9aa                                                         // b9ea: 4c aa b9    L..
 
 // $b9ed referenced 1 time by $b9de
@@ -7528,7 +7528,7 @@ sub_cb9ff
 // $ba04 referenced 1 time by $ba01
 cba04
     jsr cbc3d                                                         // ba04: 20 3d bc     =.
-    jsr osnewl                                                        // ba07: 20 e7 ff     ..            // Write newline (character 10)
+    jsr osnewl                                                        // ba07: 20 e7 ff     ..            // Write newline (characters 10 and 13)
     lda #osbyte_acknowledge_escape                                    // ba0a: a9 7e       .~
     jsr osbyte                                                        // ba0c: 20 f4 ff     ..            // Clear escape condition and perform escape effects
     lda #$11                                                          // ba0f: a9 11       ..
@@ -7668,7 +7668,7 @@ cbac0
     bpl loop_cbab6                                                    // bacd: 10 e7       ..
 // $bacf referenced 1 time by $baca
 cbacf
-    jsr osnewl                                                        // bacf: 20 e7 ff     ..            // Write newline (character 10)
+    jsr osnewl                                                        // bacf: 20 e7 ff     ..            // Write newline (characters 10 and 13)
     plp                                                               // bad2: 28          (
     bcs cbad8                                                         // bad3: b0 03       ..
     jmp cba33                                                         // bad5: 4c 33 ba    L3.
@@ -7695,8 +7695,8 @@ loop_cbaf2
     and #$0f                                                          // baf8: 29 0f       ).
     dex                                                               // bafa: ca          .
     bpl loop_cbaf2                                                    // bafb: 10 f5       ..
-    jsr osnewl                                                        // bafd: 20 e7 ff     ..            // Write newline (character 10)
-    jmp osnewl                                                        // bb00: 4c e7 ff    L..            // Write newline (character 10)
+    jsr osnewl                                                        // bafd: 20 e7 ff     ..            // Write newline (characters 10 and 13)
+    jmp osnewl                                                        // bb00: 4c e7 ff    L..            // Write newline (characters 10 and 13)
 
 // $bb03 referenced 2 times by $ba92, $baf2
 sub_cbb03

--- a/examples/known_good/basic4_acme.asm
+++ b/examples/known_good/basic4_acme.asm
@@ -13,6 +13,7 @@ osbyte_read_tube_presence              = 234
 osbyte_read_write_basic_rom_bank       = 187
 osfile_load                            = 255
 osfile_save                            = 0
+osfind_close                           = 0
 osword_read_clock                      = 1
 osword_read_cmos_clock                 = 14
 osword_read_io_memory                  = 5
@@ -10832,7 +10833,7 @@ sub_cbeee
     jsr sub_cba6e                                                     ; beee: 20 6e ba     n.
     jsr sub_c9c5a                                                     ; bef1: 20 5a 9c     Z.
     ldy l002a                                                         ; bef4: a4 2a       .*
-    lda #0                                                            ; bef6: a9 00       ..
+    lda #osfind_close                                                 ; bef6: a9 00       ..
     jsr osfind                                                        ; bef8: 20 ce ff     ..            ; Close one or all files
     bra cbeeb                                                         ; befb: 80 ee       ..
 sub_cbefd
@@ -13974,6 +13975,9 @@ pydis_end
 }
 !if (osfile_save) != $00 {
     !error "Assertion failed: osfile_save == $00"
+}
+!if (osfind_close) != $00 {
+    !error "Assertion failed: osfind_close == $00"
 }
 !if (osword_read_clock) != $01 {
     !error "Assertion failed: osword_read_clock == $01"

--- a/examples/known_good/basic4_acme.asm
+++ b/examples/known_good/basic4_acme.asm
@@ -234,7 +234,7 @@ c804c
     lda (os_text_ptr),y                                               ; 804c: b1 f2       ..
     cmp #$0d                                                          ; 804e: c9 0d       ..
     bne c806a                                                         ; 8050: d0 18       ..
-    jsr osnewl                                                        ; 8052: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; 8052: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     ldx #$f6                                                          ; 8055: a2 f6       ..
 ; $8057 referenced 1 time by $8062
 loop_c8057
@@ -246,7 +246,7 @@ c805e
     jsr osasci                                                        ; 805e: 20 e3 ff     ..            ; Write character 32
     inx                                                               ; 8061: e8          .
     bne loop_c8057                                                    ; 8062: d0 f3       ..
-    jsr osnewl                                                        ; 8064: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; 8064: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
 ; $8067 referenced 2 times by $809c, $80a6
 c8067
     jsr sub_c80d8                                                     ; 8067: 20 d8 80     ..
@@ -10029,7 +10029,7 @@ cbaa6
 
 ; $bac2 referenced 8 times by $8a14, $8a68, $9285, $9319, $932a, $9538, $98c6, $bdc6
 sub_cbac2
-    jsr osnewl                                                        ; bac2: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; bac2: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
 ; $bac5 referenced 2 times by $babd, $bddf
 cbac5
     stz l001e                                                         ; bac5: 64 1e       d.

--- a/examples/known_good/basic4_beebasm.asm
+++ b/examples/known_good/basic4_beebasm.asm
@@ -13,6 +13,7 @@ osbyte_read_tube_presence              = 234
 osbyte_read_write_basic_rom_bank       = 187
 osfile_load                            = 255
 osfile_save                            = 0
+osfind_close                           = 0
 osword_read_clock                      = 1
 osword_read_cmos_clock                 = 14
 osword_read_io_memory                  = 5
@@ -10832,7 +10833,7 @@ lbecd = sub_cbecc+1
     jsr sub_cba6e                                                     ; beee: 20 6e ba     n.
     jsr sub_c9c5a                                                     ; bef1: 20 5a 9c     Z.
     ldy l002a                                                         ; bef4: a4 2a       .*
-    lda #0                                                            ; bef6: a9 00       ..
+    lda #osfind_close                                                 ; bef6: a9 00       ..
     jsr osfind                                                        ; bef8: 20 ce ff     ..            ; Close one or all files
     bra cbeeb                                                         ; befb: 80 ee       ..
 .sub_cbefd
@@ -13921,6 +13922,7 @@ lbefe = sub_cbefd+1
     assert osbyte_read_write_basic_rom_bank == &bb
     assert osfile_load == &ff
     assert osfile_save == &00
+    assert osfind_close == &00
     assert osword_read_clock == &01
     assert osword_read_cmos_clock == &0e
     assert osword_read_io_memory == &05

--- a/examples/known_good/basic4_beebasm.asm
+++ b/examples/known_good/basic4_beebasm.asm
@@ -234,7 +234,7 @@ oscli       = &fff7
     lda (os_text_ptr),y                                               ; 804c: b1 f2       ..
     cmp #&0d                                                          ; 804e: c9 0d       ..
     bne c806a                                                         ; 8050: d0 18       ..
-    jsr osnewl                                                        ; 8052: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; 8052: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     ldx #&f6                                                          ; 8055: a2 f6       ..
 ; &8057 referenced 1 time by &8062
 .loop_c8057
@@ -246,7 +246,7 @@ oscli       = &fff7
     jsr osasci                                                        ; 805e: 20 e3 ff     ..            ; Write character 32
     inx                                                               ; 8061: e8          .
     bne loop_c8057                                                    ; 8062: d0 f3       ..
-    jsr osnewl                                                        ; 8064: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; 8064: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
 ; &8067 referenced 2 times by &809c, &80a6
 .c8067
     jsr sub_c80d8                                                     ; 8067: 20 d8 80     ..
@@ -10029,7 +10029,7 @@ l8993 = sub_c8992+1
 
 ; &bac2 referenced 8 times by &8a14, &8a68, &9285, &9319, &932a, &9538, &98c6, &bdc6
 .sub_cbac2
-    jsr osnewl                                                        ; bac2: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; bac2: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
 ; &bac5 referenced 2 times by &babd, &bddf
 .cbac5
     stz l001e                                                         ; bac5: 64 1e       d.

--- a/examples/known_good/basic4_xa.asm
+++ b/examples/known_good/basic4_xa.asm
@@ -232,7 +232,7 @@ c804c
     lda (os_text_ptr),y                                               // 804c: b1 f2       ..
     cmp #$0d                                                          // 804e: c9 0d       ..
     bne c806a                                                         // 8050: d0 18       ..
-    jsr osnewl                                                        // 8052: 20 e7 ff     ..            // Write newline (character 10)
+    jsr osnewl                                                        // 8052: 20 e7 ff     ..            // Write newline (characters 10 and 13)
     ldx #$f6                                                          // 8055: a2 f6       ..
 // $8057 referenced 1 time by $8062
 loop_c8057
@@ -244,7 +244,7 @@ c805e
     jsr osasci                                                        // 805e: 20 e3 ff     ..            // Write character 32
     inx                                                               // 8061: e8          .
     bne loop_c8057                                                    // 8062: d0 f3       ..
-    jsr osnewl                                                        // 8064: 20 e7 ff     ..            // Write newline (character 10)
+    jsr osnewl                                                        // 8064: 20 e7 ff     ..            // Write newline (characters 10 and 13)
 // $8067 referenced 2 times by $809c, $80a6
 c8067
     jsr sub_c80d8                                                     // 8067: 20 d8 80     ..
@@ -10027,7 +10027,7 @@ cbaa6
 
 // $bac2 referenced 8 times by $8a14, $8a68, $9285, $9319, $932a, $9538, $98c6, $bdc6
 sub_cbac2
-    jsr osnewl                                                        // bac2: 20 e7 ff     ..            // Write newline (character 10)
+    jsr osnewl                                                        // bac2: 20 e7 ff     ..            // Write newline (characters 10 and 13)
 // $bac5 referenced 2 times by $babd, $bddf
 cbac5
     stz l001e                                                         // bac5: 64 1e       d.

--- a/examples/known_good/basic4_xa.asm
+++ b/examples/known_good/basic4_xa.asm
@@ -11,6 +11,7 @@ osbyte_read_tube_presence              = 234
 osbyte_read_write_basic_rom_bank       = 187
 osfile_load                            = 255
 osfile_save                            = 0
+osfind_close                           = 0
 osword_read_clock                      = 1
 osword_read_cmos_clock                 = 14
 osword_read_io_memory                  = 5
@@ -10830,7 +10831,7 @@ sub_cbeee
     jsr sub_cba6e                                                     // beee: 20 6e ba     n.
     jsr sub_c9c5a                                                     // bef1: 20 5a 9c     Z.
     ldy l002a                                                         // bef4: a4 2a       .*
-    lda #0                                                            // bef6: a9 00       ..
+    lda #osfind_close                                                 // bef6: a9 00       ..
     jsr osfind                                                        // bef8: 20 ce ff     ..            // Close one or all files
     bra cbeeb                                                         // befb: 80 ee       ..
 sub_cbefd

--- a/examples/known_good/chuckie_acme.asm
+++ b/examples/known_good/chuckie_acme.asm
@@ -101,10 +101,12 @@ inkey_key_1                       = 207
 inkey_key_2                       = 206
 inkey_key_3                       = 238
 inkey_key_4                       = 237
+inkey_key_ctrl                    = 254
 inkey_key_escape                  = 143
 inkey_key_h                       = 171
 inkey_key_k                       = 185
 inkey_key_s                       = 174
+inkey_key_shift                   = 255
 osbyte_clear_escape               = 124
 osbyte_flush_buffer_class         = 15
 osbyte_inkey                      = 129
@@ -1569,20 +1571,20 @@ printstringloop
 ; Handle keyboard input
 ; ----------------------------------------------------------------------------------
 handlekeyboard
-    ldx #inkey_key_h                                                  ; 1a3b: a2 ab       ..
+    ldx #inkey_key_h                                                  ; 1a3b: a2 ab       ..             ; X=inkey key value
     ldy #$ff                                                          ; 1a3d: a0 ff       ..
     lda #osbyte_inkey                                                 ; 1a3f: a9 81       ..
     jsr osbyte                                                        ; 1a41: 20 f4 ff     ..            ; Is the 'H' key pressed?
     cpy #0                                                            ; 1a44: c0 00       ..             ; X and Y contain $ff if the key is pressed
     beq checkkeys                                                     ; 1a46: f0 26       .&
 paused
-    ldx #inkey_key_h                                                  ; 1a48: a2 ab       ..
+    ldx #inkey_key_h                                                  ; 1a48: a2 ab       ..             ; X=inkey key value
     ldy #$ff                                                          ; 1a4a: a0 ff       ..
     lda #osbyte_inkey                                                 ; 1a4c: a9 81       ..
     jsr osbyte                                                        ; 1a4e: 20 f4 ff     ..            ; Is the 'H' key pressed?
     cpy #0                                                            ; 1a51: c0 00       ..             ; X and Y contain $ff if the key is pressed
     beq stillpaused                                                   ; 1a53: f0 12       ..
-    ldx #inkey_key_escape                                             ; 1a55: a2 8f       ..
+    ldx #inkey_key_escape                                             ; 1a55: a2 8f       ..             ; X=inkey key value
     ldy #$ff                                                          ; 1a57: a0 ff       ..
     lda #osbyte_inkey                                                 ; 1a59: a9 81       ..
     jsr osbyte                                                        ; 1a5b: 20 f4 ff     ..            ; Is the 'ESCAPE' key pressed?
@@ -3958,7 +3960,7 @@ promptpositioned
     jsr printstring                                                   ; 2906: 20 26 1a     &.
     lda #osbyte_set_cursor_editing                                    ; 2909: a9 04       ..
     ldx #1                                                            ; 290b: a2 01       ..
-    jsr osbyte                                                        ; 290d: 20 f4 ff     ..            ; Disable cursor editing (edit keys give ASCII 135-139)
+    jsr osbyte                                                        ; 290d: 20 f4 ff     ..            ; Disable cursor editing (edit keys give ASCII 135-139) (X=1)
     lda #osbyte_flush_buffer_class                                    ; 2910: a9 0f       ..
     ldx #1                                                            ; 2912: a2 01       ..
     jsr osbyte                                                        ; 2914: 20 f4 ff     ..            ; Flush input buffers (X non-zero)
@@ -4292,7 +4294,7 @@ choosenumplayers
     lda #$64                                                          ; 2b98: a9 64       .d
     sta temp5                                                         ; 2b9a: 85 8c       ..
 inputnumplayers
-    ldx #inkey_key_1                                                  ; 2b9c: a2 cf       ..
+    ldx #inkey_key_1                                                  ; 2b9c: a2 cf       ..             ; X=inkey key value
     ldy #$ff                                                          ; 2b9e: a0 ff       ..
     lda #osbyte_inkey                                                 ; 2ba0: a9 81       ..
     jsr osbyte                                                        ; 2ba2: 20 f4 ff     ..            ; Is the '1' key pressed?
@@ -4302,7 +4304,7 @@ inputnumplayers
     jmp startgame                                                     ; 2bab: 4c f1 2b    L.+
 
 not1player
-    ldx #inkey_key_2                                                  ; 2bae: a2 ce       ..
+    ldx #inkey_key_2                                                  ; 2bae: a2 ce       ..             ; X=inkey key value
     ldy #$ff                                                          ; 2bb0: a0 ff       ..
     lda #osbyte_inkey                                                 ; 2bb2: a9 81       ..
     jsr osbyte                                                        ; 2bb4: 20 f4 ff     ..            ; Is the '2' key pressed?
@@ -4312,7 +4314,7 @@ not1player
     jmp startgame                                                     ; 2bbd: 4c f1 2b    L.+
 
 not2player
-    ldx #inkey_key_3                                                  ; 2bc0: a2 ee       ..
+    ldx #inkey_key_3                                                  ; 2bc0: a2 ee       ..             ; X=inkey key value
     ldy #$ff                                                          ; 2bc2: a0 ff       ..
     lda #osbyte_inkey                                                 ; 2bc4: a9 81       ..
     jsr osbyte                                                        ; 2bc6: 20 f4 ff     ..            ; Is the '3' key pressed?
@@ -4322,7 +4324,7 @@ not2player
     jmp startgame                                                     ; 2bcf: 4c f1 2b    L.+
 
 not3player
-    ldx #inkey_key_4                                                  ; 2bd2: a2 ed       ..
+    ldx #inkey_key_4                                                  ; 2bd2: a2 ed       ..             ; X=inkey key value
     ldy #$ff                                                          ; 2bd4: a0 ff       ..
     lda #osbyte_inkey                                                 ; 2bd6: a9 81       ..
     jsr osbyte                                                        ; 2bd8: 20 f4 ff     ..            ; Is the '4' key pressed?
@@ -4566,7 +4568,7 @@ string_keyhelp_start
 string_keyhelp_end
 checktitlepagekeys_core
     lda #osbyte_inkey                                                 ; 2d88: a9 81       ..
-    ldx #inkey_key_s                                                  ; 2d8a: a2 ae       ..
+    ldx #inkey_key_s                                                  ; 2d8a: a2 ae       ..             ; X=inkey key value
     ldy #$ff                                                          ; 2d8c: a0 ff       ..
     jsr osbyte                                                        ; 2d8e: 20 f4 ff     ..            ; Is the 'S' key pressed?
     cpy #0                                                            ; 2d91: c0 00       ..             ; X and Y contain $ff if the key is pressed
@@ -4577,7 +4579,7 @@ checktitlepagekeys_core
 
 didntpressS
     lda #osbyte_inkey                                                 ; 2d99: a9 81       ..
-    ldx #inkey_key_k                                                  ; 2d9b: a2 b9       ..
+    ldx #inkey_key_k                                                  ; 2d9b: a2 b9       ..             ; X=inkey key value
     ldy #$ff                                                          ; 2d9d: a0 ff       ..
     jsr osbyte                                                        ; 2d9f: 20 f4 ff     ..            ; Is the 'K' key pressed?
     cpy #0                                                            ; 2da2: c0 00       ..             ; X and Y contain $ff if the key is pressed
@@ -5020,7 +5022,7 @@ choosekeys
 ; ----------------------------------------------------------------------------------
 waitforkey
     lda #osbyte_scan_keyboard                                         ; 305c: a9 79       .y  :095c[1]
-    ldx #$80                                                          ; 305e: a2 80       ..  :095e[1]
+    ldx #(255 - inkey_key_shift) XOR 128                              ; 305e: a2 80       ..  :095e[1]   ; X=internal key number EOR 128
     jsr osbyte                                                        ; 3060: 20 f4 ff     .. :0960[1]   ; Test for 'SHIFT' key pressed (X=128)
     txa                                                               ; 3063: 8a          .   :0963[1]   ; X has top bit set if 'SHIFT' pressed
     bpl didntpressshift                                               ; 3064: 10 05       ..  :0964[1]
@@ -5029,7 +5031,7 @@ waitforkey
 
 didntpressshift
     lda #osbyte_scan_keyboard                                         ; 306b: a9 79       .y  :096b[1]
-    ldx #$81                                                          ; 306d: a2 81       ..  :096d[1]
+    ldx #(255 - inkey_key_ctrl) XOR 128                               ; 306d: a2 81       ..  :096d[1]   ; X=internal key number EOR 128
     jsr osbyte                                                        ; 306f: 20 f4 ff     .. :096f[1]   ; Test for 'CTRL' key pressed (X=129)
     txa                                                               ; 3072: 8a          .   :0972[1]   ; X has top bit set if 'CTRL' pressed
     bpl didntpressctrl                                                ; 3073: 10 05       ..  :0973[1]
@@ -6218,6 +6220,12 @@ pydis_end
 }
 !if (((map7seed_end - map7seed_start) / 2)) != $10 {
     !error "Assertion failed: ((map7seed_end - map7seed_start) / 2) == $10"
+}
+!if ((255 - inkey_key_ctrl) XOR 128) != $81 {
+    !error "Assertion failed: (255 - inkey_key_ctrl) XOR 128 == $81"
+}
+!if ((255 - inkey_key_shift) XOR 128) != $80 {
+    !error "Assertion failed: (255 - inkey_key_shift) XOR 128 == $80"
 }
 !if ((MapId_Egg OR MapId_Seed)) != $0c {
     !error "Assertion failed: (MapId_Egg OR MapId_Seed) == $0c"

--- a/examples/known_good/chuckie_beebasm.asm
+++ b/examples/known_good/chuckie_beebasm.asm
@@ -101,10 +101,12 @@ inkey_key_1                       = 207
 inkey_key_2                       = 206
 inkey_key_3                       = 238
 inkey_key_4                       = 237
+inkey_key_ctrl                    = 254
 inkey_key_escape                  = 143
 inkey_key_h                       = 171
 inkey_key_k                       = 185
 inkey_key_s                       = 174
+inkey_key_shift                   = 255
 osbyte_clear_escape               = 124
 osbyte_flush_buffer_class         = 15
 osbyte_inkey                      = 129
@@ -1569,20 +1571,20 @@ osbyte                  = &fff4
 ; Handle keyboard input
 ; ----------------------------------------------------------------------------------
 .handlekeyboard
-    ldx #inkey_key_h                                                  ; 1a3b: a2 ab       ..
+    ldx #inkey_key_h                                                  ; 1a3b: a2 ab       ..             ; X=inkey key value
     ldy #&ff                                                          ; 1a3d: a0 ff       ..
     lda #osbyte_inkey                                                 ; 1a3f: a9 81       ..
     jsr osbyte                                                        ; 1a41: 20 f4 ff     ..            ; Is the 'H' key pressed?
     cpy #0                                                            ; 1a44: c0 00       ..             ; X and Y contain &ff if the key is pressed
     beq checkkeys                                                     ; 1a46: f0 26       .&
 .paused
-    ldx #inkey_key_h                                                  ; 1a48: a2 ab       ..
+    ldx #inkey_key_h                                                  ; 1a48: a2 ab       ..             ; X=inkey key value
     ldy #&ff                                                          ; 1a4a: a0 ff       ..
     lda #osbyte_inkey                                                 ; 1a4c: a9 81       ..
     jsr osbyte                                                        ; 1a4e: 20 f4 ff     ..            ; Is the 'H' key pressed?
     cpy #0                                                            ; 1a51: c0 00       ..             ; X and Y contain &ff if the key is pressed
     beq stillpaused                                                   ; 1a53: f0 12       ..
-    ldx #inkey_key_escape                                             ; 1a55: a2 8f       ..
+    ldx #inkey_key_escape                                             ; 1a55: a2 8f       ..             ; X=inkey key value
     ldy #&ff                                                          ; 1a57: a0 ff       ..
     lda #osbyte_inkey                                                 ; 1a59: a9 81       ..
     jsr osbyte                                                        ; 1a5b: 20 f4 ff     ..            ; Is the 'ESCAPE' key pressed?
@@ -3958,7 +3960,7 @@ osbyte                  = &fff4
     jsr printstring                                                   ; 2906: 20 26 1a     &.
     lda #osbyte_set_cursor_editing                                    ; 2909: a9 04       ..
     ldx #1                                                            ; 290b: a2 01       ..
-    jsr osbyte                                                        ; 290d: 20 f4 ff     ..            ; Disable cursor editing (edit keys give ASCII 135-139)
+    jsr osbyte                                                        ; 290d: 20 f4 ff     ..            ; Disable cursor editing (edit keys give ASCII 135-139) (X=1)
     lda #osbyte_flush_buffer_class                                    ; 2910: a9 0f       ..
     ldx #1                                                            ; 2912: a2 01       ..
     jsr osbyte                                                        ; 2914: 20 f4 ff     ..            ; Flush input buffers (X non-zero)
@@ -4292,7 +4294,7 @@ osbyte                  = &fff4
     lda #&64                                                          ; 2b98: a9 64       .d
     sta temp5                                                         ; 2b9a: 85 8c       ..
 .inputnumplayers
-    ldx #inkey_key_1                                                  ; 2b9c: a2 cf       ..
+    ldx #inkey_key_1                                                  ; 2b9c: a2 cf       ..             ; X=inkey key value
     ldy #&ff                                                          ; 2b9e: a0 ff       ..
     lda #osbyte_inkey                                                 ; 2ba0: a9 81       ..
     jsr osbyte                                                        ; 2ba2: 20 f4 ff     ..            ; Is the '1' key pressed?
@@ -4302,7 +4304,7 @@ osbyte                  = &fff4
     jmp startgame                                                     ; 2bab: 4c f1 2b    L.+
 
 .not1player
-    ldx #inkey_key_2                                                  ; 2bae: a2 ce       ..
+    ldx #inkey_key_2                                                  ; 2bae: a2 ce       ..             ; X=inkey key value
     ldy #&ff                                                          ; 2bb0: a0 ff       ..
     lda #osbyte_inkey                                                 ; 2bb2: a9 81       ..
     jsr osbyte                                                        ; 2bb4: 20 f4 ff     ..            ; Is the '2' key pressed?
@@ -4312,7 +4314,7 @@ osbyte                  = &fff4
     jmp startgame                                                     ; 2bbd: 4c f1 2b    L.+
 
 .not2player
-    ldx #inkey_key_3                                                  ; 2bc0: a2 ee       ..
+    ldx #inkey_key_3                                                  ; 2bc0: a2 ee       ..             ; X=inkey key value
     ldy #&ff                                                          ; 2bc2: a0 ff       ..
     lda #osbyte_inkey                                                 ; 2bc4: a9 81       ..
     jsr osbyte                                                        ; 2bc6: 20 f4 ff     ..            ; Is the '3' key pressed?
@@ -4322,7 +4324,7 @@ osbyte                  = &fff4
     jmp startgame                                                     ; 2bcf: 4c f1 2b    L.+
 
 .not3player
-    ldx #inkey_key_4                                                  ; 2bd2: a2 ed       ..
+    ldx #inkey_key_4                                                  ; 2bd2: a2 ed       ..             ; X=inkey key value
     ldy #&ff                                                          ; 2bd4: a0 ff       ..
     lda #osbyte_inkey                                                 ; 2bd6: a9 81       ..
     jsr osbyte                                                        ; 2bd8: 20 f4 ff     ..            ; Is the '4' key pressed?
@@ -4566,7 +4568,7 @@ osbyte                  = &fff4
 .string_keyhelp_end
 .checktitlepagekeys_core
     lda #osbyte_inkey                                                 ; 2d88: a9 81       ..
-    ldx #inkey_key_s                                                  ; 2d8a: a2 ae       ..
+    ldx #inkey_key_s                                                  ; 2d8a: a2 ae       ..             ; X=inkey key value
     ldy #&ff                                                          ; 2d8c: a0 ff       ..
     jsr osbyte                                                        ; 2d8e: 20 f4 ff     ..            ; Is the 'S' key pressed?
     cpy #0                                                            ; 2d91: c0 00       ..             ; X and Y contain &ff if the key is pressed
@@ -4577,7 +4579,7 @@ osbyte                  = &fff4
 
 .didntpressS
     lda #osbyte_inkey                                                 ; 2d99: a9 81       ..
-    ldx #inkey_key_k                                                  ; 2d9b: a2 b9       ..
+    ldx #inkey_key_k                                                  ; 2d9b: a2 b9       ..             ; X=inkey key value
     ldy #&ff                                                          ; 2d9d: a0 ff       ..
     jsr osbyte                                                        ; 2d9f: 20 f4 ff     ..            ; Is the 'K' key pressed?
     cpy #0                                                            ; 2da2: c0 00       ..             ; X and Y contain &ff if the key is pressed
@@ -5020,7 +5022,7 @@ osbyte                  = &fff4
 ; ----------------------------------------------------------------------------------
 .waitforkey
     lda #osbyte_scan_keyboard                                         ; 305c: a9 79       .y  :095c[1]
-    ldx #&80                                                          ; 305e: a2 80       ..  :095e[1]
+    ldx #(255 - inkey_key_shift) EOR 128                              ; 305e: a2 80       ..  :095e[1]   ; X=internal key number EOR 128
     jsr osbyte                                                        ; 3060: 20 f4 ff     .. :0960[1]   ; Test for 'SHIFT' key pressed (X=128)
     txa                                                               ; 3063: 8a          .   :0963[1]   ; X has top bit set if 'SHIFT' pressed
     bpl didntpressshift                                               ; 3064: 10 05       ..  :0964[1]
@@ -5029,7 +5031,7 @@ osbyte                  = &fff4
 
 .didntpressshift
     lda #osbyte_scan_keyboard                                         ; 306b: a9 79       .y  :096b[1]
-    ldx #&81                                                          ; 306d: a2 81       ..  :096d[1]
+    ldx #(255 - inkey_key_ctrl) EOR 128                               ; 306d: a2 81       ..  :096d[1]   ; X=internal key number EOR 128
     jsr osbyte                                                        ; 306f: 20 f4 ff     .. :096f[1]   ; Test for 'CTRL' key pressed (X=129)
     txa                                                               ; 3072: 8a          .   :0972[1]   ; X has top bit set if 'CTRL' pressed
     bpl didntpressctrl                                                ; 3073: 10 05       ..  :0973[1]
@@ -6173,6 +6175,8 @@ osbyte                  = &fff4
     assert ((map7ladder_end - map7ladder_start) / 3) == &06
     assert ((map7platform_end - map7platform_start) / 3) == &0f
     assert ((map7seed_end - map7seed_start) / 2) == &10
+    assert (255 - inkey_key_ctrl) EOR 128 == &81
+    assert (255 - inkey_key_shift) EOR 128 == &80
     assert (MapId_Egg OR MapId_Seed) == &0c
     assert 255 - inkey_key_h == &54
     assert <(blipsoundblock) == &98

--- a/examples/known_good/chuckie_xa.asm
+++ b/examples/known_good/chuckie_xa.asm
@@ -101,10 +101,12 @@ inkey_key_1                       = 207
 inkey_key_2                       = 206
 inkey_key_3                       = 238
 inkey_key_4                       = 237
+inkey_key_ctrl                    = 254
 inkey_key_escape                  = 143
 inkey_key_h                       = 171
 inkey_key_k                       = 185
 inkey_key_s                       = 174
+inkey_key_shift                   = 255
 osbyte_clear_escape               = 124
 osbyte_flush_buffer_class         = 15
 osbyte_inkey                      = 129
@@ -1569,20 +1571,20 @@ printstringloop
 // Handle keyboard input
 // ----------------------------------------------------------------------------------
 handlekeyboard
-    ldx #inkey_key_h                                                  // 1a3b: a2 ab       ..
+    ldx #inkey_key_h                                                  // 1a3b: a2 ab       ..             // X=inkey key value
     ldy #$ff                                                          // 1a3d: a0 ff       ..
     lda #osbyte_inkey                                                 // 1a3f: a9 81       ..
     jsr osbyte                                                        // 1a41: 20 f4 ff     ..            // Is the 'H' key pressed?
     cpy #0                                                            // 1a44: c0 00       ..             // X and Y contain $ff if the key is pressed
     beq checkkeys                                                     // 1a46: f0 26       .&
 paused
-    ldx #inkey_key_h                                                  // 1a48: a2 ab       ..
+    ldx #inkey_key_h                                                  // 1a48: a2 ab       ..             // X=inkey key value
     ldy #$ff                                                          // 1a4a: a0 ff       ..
     lda #osbyte_inkey                                                 // 1a4c: a9 81       ..
     jsr osbyte                                                        // 1a4e: 20 f4 ff     ..            // Is the 'H' key pressed?
     cpy #0                                                            // 1a51: c0 00       ..             // X and Y contain $ff if the key is pressed
     beq stillpaused                                                   // 1a53: f0 12       ..
-    ldx #inkey_key_escape                                             // 1a55: a2 8f       ..
+    ldx #inkey_key_escape                                             // 1a55: a2 8f       ..             // X=inkey key value
     ldy #$ff                                                          // 1a57: a0 ff       ..
     lda #osbyte_inkey                                                 // 1a59: a9 81       ..
     jsr osbyte                                                        // 1a5b: 20 f4 ff     ..            // Is the 'ESCAPE' key pressed?
@@ -3958,7 +3960,7 @@ promptpositioned
     jsr printstring                                                   // 2906: 20 26 1a     &.
     lda #osbyte_set_cursor_editing                                    // 2909: a9 04       ..
     ldx #1                                                            // 290b: a2 01       ..
-    jsr osbyte                                                        // 290d: 20 f4 ff     ..            // Disable cursor editing (edit keys give ASCII 135-139)
+    jsr osbyte                                                        // 290d: 20 f4 ff     ..            // Disable cursor editing (edit keys give ASCII 135-139) (X=1)
     lda #osbyte_flush_buffer_class                                    // 2910: a9 0f       ..
     ldx #1                                                            // 2912: a2 01       ..
     jsr osbyte                                                        // 2914: 20 f4 ff     ..            // Flush input buffers (X non-zero)
@@ -4292,7 +4294,7 @@ choosenumplayers
     lda #$64                                                          // 2b98: a9 64       .d
     sta temp5                                                         // 2b9a: 85 8c       ..
 inputnumplayers
-    ldx #inkey_key_1                                                  // 2b9c: a2 cf       ..
+    ldx #inkey_key_1                                                  // 2b9c: a2 cf       ..             // X=inkey key value
     ldy #$ff                                                          // 2b9e: a0 ff       ..
     lda #osbyte_inkey                                                 // 2ba0: a9 81       ..
     jsr osbyte                                                        // 2ba2: 20 f4 ff     ..            // Is the '1' key pressed?
@@ -4302,7 +4304,7 @@ inputnumplayers
     jmp startgame                                                     // 2bab: 4c f1 2b    L.+
 
 not1player
-    ldx #inkey_key_2                                                  // 2bae: a2 ce       ..
+    ldx #inkey_key_2                                                  // 2bae: a2 ce       ..             // X=inkey key value
     ldy #$ff                                                          // 2bb0: a0 ff       ..
     lda #osbyte_inkey                                                 // 2bb2: a9 81       ..
     jsr osbyte                                                        // 2bb4: 20 f4 ff     ..            // Is the '2' key pressed?
@@ -4312,7 +4314,7 @@ not1player
     jmp startgame                                                     // 2bbd: 4c f1 2b    L.+
 
 not2player
-    ldx #inkey_key_3                                                  // 2bc0: a2 ee       ..
+    ldx #inkey_key_3                                                  // 2bc0: a2 ee       ..             // X=inkey key value
     ldy #$ff                                                          // 2bc2: a0 ff       ..
     lda #osbyte_inkey                                                 // 2bc4: a9 81       ..
     jsr osbyte                                                        // 2bc6: 20 f4 ff     ..            // Is the '3' key pressed?
@@ -4322,7 +4324,7 @@ not2player
     jmp startgame                                                     // 2bcf: 4c f1 2b    L.+
 
 not3player
-    ldx #inkey_key_4                                                  // 2bd2: a2 ed       ..
+    ldx #inkey_key_4                                                  // 2bd2: a2 ed       ..             // X=inkey key value
     ldy #$ff                                                          // 2bd4: a0 ff       ..
     lda #osbyte_inkey                                                 // 2bd6: a9 81       ..
     jsr osbyte                                                        // 2bd8: 20 f4 ff     ..            // Is the '4' key pressed?
@@ -4566,7 +4568,7 @@ string_keyhelp_start
 string_keyhelp_end
 checktitlepagekeys_core
     lda #osbyte_inkey                                                 // 2d88: a9 81       ..
-    ldx #inkey_key_s                                                  // 2d8a: a2 ae       ..
+    ldx #inkey_key_s                                                  // 2d8a: a2 ae       ..             // X=inkey key value
     ldy #$ff                                                          // 2d8c: a0 ff       ..
     jsr osbyte                                                        // 2d8e: 20 f4 ff     ..            // Is the 'S' key pressed?
     cpy #0                                                            // 2d91: c0 00       ..             // X and Y contain $ff if the key is pressed
@@ -4577,7 +4579,7 @@ checktitlepagekeys_core
 
 didntpressS
     lda #osbyte_inkey                                                 // 2d99: a9 81       ..
-    ldx #inkey_key_k                                                  // 2d9b: a2 b9       ..
+    ldx #inkey_key_k                                                  // 2d9b: a2 b9       ..             // X=inkey key value
     ldy #$ff                                                          // 2d9d: a0 ff       ..
     jsr osbyte                                                        // 2d9f: 20 f4 ff     ..            // Is the 'K' key pressed?
     cpy #0                                                            // 2da2: c0 00       ..             // X and Y contain $ff if the key is pressed
@@ -5019,7 +5021,7 @@ choosekeys
 // ----------------------------------------------------------------------------------
 waitforkey
     lda #osbyte_scan_keyboard                                         // 305c: a9 79       .y  :095c[1]
-    ldx #$80                                                          // 305e: a2 80       ..  :095e[1]
+    ldx #(255 - inkey_key_shift) ^ 128                                // 305e: a2 80       ..  :095e[1]   // X=internal key number EOR 128
     jsr osbyte                                                        // 3060: 20 f4 ff     .. :0960[1]   // Test for 'SHIFT' key pressed (X=128)
     txa                                                               // 3063: 8a          .   :0963[1]   // X has top bit set if 'SHIFT' pressed
     bpl didntpressshift                                               // 3064: 10 05       ..  :0964[1]
@@ -5028,7 +5030,7 @@ waitforkey
 
 didntpressshift
     lda #osbyte_scan_keyboard                                         // 306b: a9 79       .y  :096b[1]
-    ldx #$81                                                          // 306d: a2 81       ..  :096d[1]
+    ldx #(255 - inkey_key_ctrl) ^ 128                                 // 306d: a2 81       ..  :096d[1]   // X=internal key number EOR 128
     jsr osbyte                                                        // 306f: 20 f4 ff     .. :096f[1]   // Test for 'CTRL' key pressed (X=129)
     txa                                                               // 3072: 8a          .   :0972[1]   // X has top bit set if 'CTRL' pressed
     bpl didntpressctrl                                                // 3073: 10 05       ..  :0973[1]

--- a/examples/known_good/dfs226_acme.asm
+++ b/examples/known_good/dfs226_acme.asm
@@ -17,6 +17,9 @@ osbyte_write_shadow_memory_use        = 114
 osfile_load                           = 255
 osfile_read_catalogue_info            = 5
 osfile_save                           = 0
+osfind_close                          = 0
+osfind_open_input                     = 64
+osfind_open_output                    = 128
 service_absolute_workspace_claimed    = 10
 service_boot                          = 3
 service_check_swr_presence            = 43
@@ -7301,7 +7304,7 @@ sub_cab04
 ; $ab09 referenced 1 time by $ab02
 cab09
     sta l00ab                                                         ; ab09: 85 ab       ..
-    lda #$40 ; '@'                                                    ; ab0b: a9 40       .@
+    lda #osfind_open_input                                            ; ab0b: a9 40       .@
     jsr osfind                                                        ; ab0d: 20 ce ff     ..            ; Open file for input (A=64)
     tay                                                               ; ab10: a8          .              ; A=file handle (or zero on failure)
     lda #$0d                                                          ; ab11: a9 0d       ..
@@ -7341,12 +7344,12 @@ cab3d
     jsr osnewl                                                        ; ab3e: 20 e7 ff     ..            ; Write newline (character 10)
 ; $ab41 referenced 2 times by $aba5, $abbf
 cab41
-    lda #0                                                            ; ab41: a9 00       ..
+    lda #osfind_close                                                 ; ab41: a9 00       ..
     jmp osfind                                                        ; ab43: 4c ce ff    L..            ; Close one or all files
 
 sub_cab46
     jsr sub_cac18                                                     ; ab46: 20 18 ac     ..
-    lda #$40 ; '@'                                                    ; ab49: a9 40       .@
+    lda #osfind_open_input                                            ; ab49: a9 40       .@
     jsr osfind                                                        ; ab4b: 20 ce ff     ..            ; Open file for input (A=64)
     tay                                                               ; ab4e: a8          .              ; A=file handle (or zero on failure)
     beq cab17                                                         ; ab4f: f0 c6       ..
@@ -7424,7 +7427,7 @@ cabbc
 
 sub_cabc5
     jsr sub_cac18                                                     ; abc5: 20 18 ac     ..
-    lda #$80                                                          ; abc8: a9 80       ..
+    lda #osfind_open_output                                           ; abc8: a9 80       ..
     jsr osfind                                                        ; abca: 20 ce ff     ..            ; Open file for output (A=128)
     sta l00ab                                                         ; abcd: 85 ab       ..             ; A=file handle (or zero on failure)
 ; $abcf referenced 1 time by $ac09
@@ -7660,7 +7663,7 @@ sub_c0542
 c0552
     jsr read_tube_r2_data                                             ; ad2d: 20 c5 06     .. :0552[2]
     tay                                                               ; ad30: a8          .   :0555[2]
-    lda #0                                                            ; ad31: a9 00       ..  :0556[2]
+    lda #osfind_close                                                 ; ad31: a9 00       ..  :0556[2]
     jsr osfind                                                        ; ad33: 20 ce ff     .. :0558[2]   ; Close one or all files
     jmp c059c                                                         ; ad36: 4c 9c 05    L.. :055b[2]
 
@@ -9023,7 +9026,7 @@ sub_cb5f2
     sta (l00b8),y                                                     ; b5fb: 91 b8       ..
     pla                                                               ; b5fd: 68          h
     tay                                                               ; b5fe: a8          .
-    lda #0                                                            ; b5ff: a9 00       ..
+    lda #osfind_close                                                 ; b5ff: a9 00       ..
     jsr osfind                                                        ; b601: 20 ce ff     ..            ; Close one or all files
     jmp cb82b                                                         ; b604: 4c 2b b8    L+.
 
@@ -13915,6 +13918,15 @@ pydis_end
 }
 !if (osfile_save) != $00 {
     !error "Assertion failed: osfile_save == $00"
+}
+!if (osfind_close) != $00 {
+    !error "Assertion failed: osfind_close == $00"
+}
+!if (osfind_open_input) != $40 {
+    !error "Assertion failed: osfind_open_input == $40"
+}
+!if (osfind_open_output) != $80 {
+    !error "Assertion failed: osfind_open_output == $80"
 }
 !if (service_absolute_workspace_claimed) != $0a {
     !error "Assertion failed: service_absolute_workspace_claimed == $0a"

--- a/examples/known_good/dfs226_acme.asm
+++ b/examples/known_good/dfs226_acme.asm
@@ -7341,7 +7341,7 @@ cab35
 ; $ab3d referenced 1 time by $ab1d
 cab3d
     plp                                                               ; ab3d: 28          (
-    jsr osnewl                                                        ; ab3e: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; ab3e: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
 ; $ab41 referenced 2 times by $aba5, $abbf
 cab41
     lda #osfind_close                                                 ; ab41: a9 00       ..
@@ -7393,7 +7393,7 @@ loop_cab80
 ; $ab93 referenced 1 time by $ab7e
 cab93
     jsr sub_caba9                                                     ; ab93: 20 a9 ab     ..
-    jsr osnewl                                                        ; ab96: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; ab96: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     lda #8                                                            ; ab99: a9 08       ..
     clc                                                               ; ab9b: 18          .
     adc l00a8                                                         ; ab9c: 65 a8       e.
@@ -10580,7 +10580,7 @@ cbeee
     ldy #$7f                                                          ; bf03: a0 7f       ..
     jsr sub_cbf84                                                     ; bf05: 20 84 bf     ..
     bpl cbee8                                                         ; bf08: 10 de       ..
-    jsr osnewl                                                        ; bf0a: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; bf0a: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     ldx #0                                                            ; bf0d: a2 00       ..
     jsr sub_cbf7c                                                     ; bf0f: 20 7c bf     |.
     lda #$fd                                                          ; bf12: a9 fd       ..
@@ -10623,8 +10623,8 @@ cbf33
     jsr sub_cbf7c                                                     ; bf43: 20 7c bf     |.
 ; $bf46 referenced 1 time by $bf17
 cbf46
-    jsr osnewl                                                        ; bf46: 20 e7 ff     ..            ; Write newline (character 10)
-    jsr osnewl                                                        ; bf49: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; bf46: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
+    jsr osnewl                                                        ; bf49: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     jmp cbee8                                                         ; bf4c: 4c e8 be    L..
 
 ; $bf4f referenced 1 time by $bf7c

--- a/examples/known_good/dfs226_beebasm.asm
+++ b/examples/known_good/dfs226_beebasm.asm
@@ -17,6 +17,9 @@ osbyte_write_shadow_memory_use        = 114
 osfile_load                           = 255
 osfile_read_catalogue_info            = 5
 osfile_save                           = 0
+osfind_close                          = 0
+osfind_open_input                     = 64
+osfind_open_output                    = 128
 service_absolute_workspace_claimed    = 10
 service_boot                          = 3
 service_check_swr_presence            = 43
@@ -7314,7 +7317,7 @@ nmi_XXX5 = l0d1f+1
 ; &ab09 referenced 1 time by &ab02
 .cab09
     sta l00ab                                                         ; ab09: 85 ab       ..
-    lda #&40 ; '@'                                                    ; ab0b: a9 40       .@
+    lda #osfind_open_input                                            ; ab0b: a9 40       .@
     jsr osfind                                                        ; ab0d: 20 ce ff     ..            ; Open file for input (A=64)
     tay                                                               ; ab10: a8          .              ; A=file handle (or zero on failure)
     lda #&0d                                                          ; ab11: a9 0d       ..
@@ -7354,12 +7357,12 @@ nmi_XXX5 = l0d1f+1
     jsr osnewl                                                        ; ab3e: 20 e7 ff     ..            ; Write newline (character 10)
 ; &ab41 referenced 2 times by &aba5, &abbf
 .cab41
-    lda #0                                                            ; ab41: a9 00       ..
+    lda #osfind_close                                                 ; ab41: a9 00       ..
     jmp osfind                                                        ; ab43: 4c ce ff    L..            ; Close one or all files
 
 .sub_cab46
     jsr sub_cac18                                                     ; ab46: 20 18 ac     ..
-    lda #&40 ; '@'                                                    ; ab49: a9 40       .@
+    lda #osfind_open_input                                            ; ab49: a9 40       .@
     jsr osfind                                                        ; ab4b: 20 ce ff     ..            ; Open file for input (A=64)
     tay                                                               ; ab4e: a8          .              ; A=file handle (or zero on failure)
     beq cab17                                                         ; ab4f: f0 c6       ..
@@ -7437,7 +7440,7 @@ nmi_XXX5 = l0d1f+1
 
 .sub_cabc5
     jsr sub_cac18                                                     ; abc5: 20 18 ac     ..
-    lda #&80                                                          ; abc8: a9 80       ..
+    lda #osfind_open_output                                           ; abc8: a9 80       ..
     jsr osfind                                                        ; abca: 20 ce ff     ..            ; Open file for output (A=128)
     sta l00ab                                                         ; abcd: 85 ab       ..             ; A=file handle (or zero on failure)
 ; &abcf referenced 1 time by &ac09
@@ -7673,7 +7676,7 @@ nmi_XXX5 = l0d1f+1
 .c0552
     jsr read_tube_r2_data                                             ; ad2d: 20 c5 06     .. :0552[2]
     tay                                                               ; ad30: a8          .   :0555[2]
-    lda #0                                                            ; ad31: a9 00       ..  :0556[2]
+    lda #osfind_close                                                 ; ad31: a9 00       ..  :0556[2]
     jsr osfind                                                        ; ad33: 20 ce ff     .. :0558[2]   ; Close one or all files
     jmp c059c                                                         ; ad36: 4c 9c 05    L.. :055b[2]
 
@@ -9040,7 +9043,7 @@ jump_address_low = sub_c0050+1
     sta (l00b8),y                                                     ; b5fb: 91 b8       ..
     pla                                                               ; b5fd: 68          h
     tay                                                               ; b5fe: a8          .
-    lda #0                                                            ; b5ff: a9 00       ..
+    lda #osfind_close                                                 ; b5ff: a9 00       ..
     jsr osfind                                                        ; b601: 20 ce ff     ..            ; Close one or all files
     jmp cb82b                                                         ; b604: 4c 2b b8    L+.
 
@@ -13702,6 +13705,9 @@ lb6ce = sub_cb6cd+1
     assert osfile_load == &ff
     assert osfile_read_catalogue_info == &05
     assert osfile_save == &00
+    assert osfind_close == &00
+    assert osfind_open_input == &40
+    assert osfind_open_output == &80
     assert service_absolute_workspace_claimed == &0a
     assert service_boot == &03
     assert service_check_swr_presence == &2b

--- a/examples/known_good/dfs226_beebasm.asm
+++ b/examples/known_good/dfs226_beebasm.asm
@@ -7354,7 +7354,7 @@ nmi_XXX5 = l0d1f+1
 ; &ab3d referenced 1 time by &ab1d
 .cab3d
     plp                                                               ; ab3d: 28          (
-    jsr osnewl                                                        ; ab3e: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; ab3e: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
 ; &ab41 referenced 2 times by &aba5, &abbf
 .cab41
     lda #osfind_close                                                 ; ab41: a9 00       ..
@@ -7406,7 +7406,7 @@ nmi_XXX5 = l0d1f+1
 ; &ab93 referenced 1 time by &ab7e
 .cab93
     jsr sub_caba9                                                     ; ab93: 20 a9 ab     ..
-    jsr osnewl                                                        ; ab96: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; ab96: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     lda #8                                                            ; ab99: a9 08       ..
     clc                                                               ; ab9b: 18          .
     adc l00a8                                                         ; ab9c: 65 a8       e.
@@ -10597,7 +10597,7 @@ lb6ce = sub_cb6cd+1
     ldy #&7f                                                          ; bf03: a0 7f       ..
     jsr sub_cbf84                                                     ; bf05: 20 84 bf     ..
     bpl cbee8                                                         ; bf08: 10 de       ..
-    jsr osnewl                                                        ; bf0a: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; bf0a: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     ldx #0                                                            ; bf0d: a2 00       ..
     jsr sub_cbf7c                                                     ; bf0f: 20 7c bf     |.
     lda #&fd                                                          ; bf12: a9 fd       ..
@@ -10640,8 +10640,8 @@ lb6ce = sub_cb6cd+1
     jsr sub_cbf7c                                                     ; bf43: 20 7c bf     |.
 ; &bf46 referenced 1 time by &bf17
 .cbf46
-    jsr osnewl                                                        ; bf46: 20 e7 ff     ..            ; Write newline (character 10)
-    jsr osnewl                                                        ; bf49: 20 e7 ff     ..            ; Write newline (character 10)
+    jsr osnewl                                                        ; bf46: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
+    jsr osnewl                                                        ; bf49: 20 e7 ff     ..            ; Write newline (characters 10 and 13)
     jmp cbee8                                                         ; bf4c: 4c e8 be    L..
 
 ; &bf4f referenced 1 time by &bf7c

--- a/examples/known_good/dfs226_xa.asm
+++ b/examples/known_good/dfs226_xa.asm
@@ -7335,7 +7335,7 @@ cab35
 // $ab3d referenced 1 time by $ab1d
 cab3d
     plp                                                               // ab3d: 28          (
-    jsr osnewl                                                        // ab3e: 20 e7 ff     ..            // Write newline (character 10)
+    jsr osnewl                                                        // ab3e: 20 e7 ff     ..            // Write newline (characters 10 and 13)
 // $ab41 referenced 2 times by $aba5, $abbf
 cab41
     lda #osfind_close                                                 // ab41: a9 00       ..
@@ -7387,7 +7387,7 @@ loop_cab80
 // $ab93 referenced 1 time by $ab7e
 cab93
     jsr sub_caba9                                                     // ab93: 20 a9 ab     ..
-    jsr osnewl                                                        // ab96: 20 e7 ff     ..            // Write newline (character 10)
+    jsr osnewl                                                        // ab96: 20 e7 ff     ..            // Write newline (characters 10 and 13)
     lda #8                                                            // ab99: a9 08       ..
     clc                                                               // ab9b: 18          .
     adc l00a8                                                         // ab9c: 65 a8       e.
@@ -10566,7 +10566,7 @@ cbeee
     ldy #$7f                                                          // bf03: a0 7f       ..
     jsr sub_cbf84                                                     // bf05: 20 84 bf     ..
     bpl cbee8                                                         // bf08: 10 de       ..
-    jsr osnewl                                                        // bf0a: 20 e7 ff     ..            // Write newline (character 10)
+    jsr osnewl                                                        // bf0a: 20 e7 ff     ..            // Write newline (characters 10 and 13)
     ldx #0                                                            // bf0d: a2 00       ..
     jsr sub_cbf7c                                                     // bf0f: 20 7c bf     |.
     lda #$fd                                                          // bf12: a9 fd       ..
@@ -10609,8 +10609,8 @@ cbf33
     jsr sub_cbf7c                                                     // bf43: 20 7c bf     |.
 // $bf46 referenced 1 time by $bf17
 cbf46
-    jsr osnewl                                                        // bf46: 20 e7 ff     ..            // Write newline (character 10)
-    jsr osnewl                                                        // bf49: 20 e7 ff     ..            // Write newline (character 10)
+    jsr osnewl                                                        // bf46: 20 e7 ff     ..            // Write newline (characters 10 and 13)
+    jsr osnewl                                                        // bf49: 20 e7 ff     ..            // Write newline (characters 10 and 13)
     jmp cbee8                                                         // bf4c: 4c e8 be    L..
 
 // $bf4f referenced 1 time by $bf7c

--- a/examples/known_good/dfs226_xa.asm
+++ b/examples/known_good/dfs226_xa.asm
@@ -17,6 +17,9 @@ osbyte_write_shadow_memory_use        = 114
 osfile_load                           = 255
 osfile_read_catalogue_info            = 5
 osfile_save                           = 0
+osfind_close                          = 0
+osfind_open_input                     = 64
+osfind_open_output                    = 128
 service_absolute_workspace_claimed    = 10
 service_boot                          = 3
 service_check_swr_presence            = 43
@@ -7295,7 +7298,7 @@ sub_cab04
 // $ab09 referenced 1 time by $ab02
 cab09
     sta l00ab                                                         // ab09: 85 ab       ..
-    lda #$40 // '@'                                                   // ab0b: a9 40       .@
+    lda #osfind_open_input                                            // ab0b: a9 40       .@
     jsr osfind                                                        // ab0d: 20 ce ff     ..            // Open file for input (A=64)
     tay                                                               // ab10: a8          .              // A=file handle (or zero on failure)
     lda #$0d                                                          // ab11: a9 0d       ..
@@ -7335,12 +7338,12 @@ cab3d
     jsr osnewl                                                        // ab3e: 20 e7 ff     ..            // Write newline (character 10)
 // $ab41 referenced 2 times by $aba5, $abbf
 cab41
-    lda #0                                                            // ab41: a9 00       ..
+    lda #osfind_close                                                 // ab41: a9 00       ..
     jmp osfind                                                        // ab43: 4c ce ff    L..            // Close one or all files
 
 sub_cab46
     jsr sub_cac18                                                     // ab46: 20 18 ac     ..
-    lda #$40 // '@'                                                   // ab49: a9 40       .@
+    lda #osfind_open_input                                            // ab49: a9 40       .@
     jsr osfind                                                        // ab4b: 20 ce ff     ..            // Open file for input (A=64)
     tay                                                               // ab4e: a8          .              // A=file handle (or zero on failure)
     beq cab17                                                         // ab4f: f0 c6       ..
@@ -7418,7 +7421,7 @@ cabbc
 
 sub_cabc5
     jsr sub_cac18                                                     // abc5: 20 18 ac     ..
-    lda #$80                                                          // abc8: a9 80       ..
+    lda #osfind_open_output                                           // abc8: a9 80       ..
     jsr osfind                                                        // abca: 20 ce ff     ..            // Open file for output (A=128)
     sta l00ab                                                         // abcd: 85 ab       ..             // A=file handle (or zero on failure)
 // $abcf referenced 1 time by $ac09
@@ -7653,7 +7656,7 @@ sub_c0542
 c0552
     jsr read_tube_r2_data                                             // ad2d: 20 c5 06     .. :0552[2]
     tay                                                               // ad30: a8          .   :0555[2]
-    lda #0                                                            // ad31: a9 00       ..  :0556[2]
+    lda #osfind_close                                                 // ad31: a9 00       ..  :0556[2]
     jsr osfind                                                        // ad33: 20 ce ff     .. :0558[2]   // Close one or all files
     jmp c059c                                                         // ad36: 4c 9c 05    L.. :055b[2]
 
@@ -9009,7 +9012,7 @@ sub_cb5f2
     sta (l00b8),y                                                     // b5fb: 91 b8       ..
     pla                                                               // b5fd: 68          h
     tay                                                               // b5fe: a8          .
-    lda #0                                                            // b5ff: a9 00       ..
+    lda #osfind_close                                                 // b5ff: a9 00       ..
     jsr osfind                                                        // b601: 20 ce ff     ..            // Close one or all files
     jmp cb82b                                                         // b604: 4c 2b b8    L+.
 

--- a/examples/known_good/dfs226b_acme.asm
+++ b/examples/known_good/dfs226b_acme.asm
@@ -17,6 +17,9 @@ osbyte_write_shadow_memory_use        = 114
 osfile_load                           = 255
 osfile_read_catalogue_info            = 5
 osfile_save                           = 0
+osfind_close                          = 0
+osfind_open_input                     = 64
+osfind_open_output                    = 128
 service_absolute_workspace_claimed    = 10
 service_boot                          = 3
 service_check_swr_presence            = 43
@@ -7303,7 +7306,7 @@ sub_cab04
 ; $4b09 referenced 1 time by $ab02
 cab09
     sta l00ab                                                         ; 4b09: 85 ab       ..  :ab09[1]
-    lda #$40 ; '@'                                                    ; 4b0b: a9 40       .@  :ab0b[1]
+    lda #osfind_open_input                                            ; 4b0b: a9 40       .@  :ab0b[1]
     jsr osfind                                                        ; 4b0d: 20 ce ff     .. :ab0d[1]   ; Open file for input (A=64)
     tay                                                               ; 4b10: a8          .   :ab10[1]   ; A=file handle (or zero on failure)
     lda #$0d                                                          ; 4b11: a9 0d       ..  :ab11[1]
@@ -7343,12 +7346,12 @@ cab3d
     jsr osnewl                                                        ; 4b3e: 20 e7 ff     .. :ab3e[1]   ; Write newline (character 10)
 ; $4b41 referenced 2 times by $aba5, $abbf
 cab41
-    lda #0                                                            ; 4b41: a9 00       ..  :ab41[1]
+    lda #osfind_close                                                 ; 4b41: a9 00       ..  :ab41[1]
     jmp osfind                                                        ; 4b43: 4c ce ff    L.. :ab43[1]   ; Close one or all files
 
 sub_cab46
     jsr sub_cac18                                                     ; 4b46: 20 18 ac     .. :ab46[1]
-    lda #$40 ; '@'                                                    ; 4b49: a9 40       .@  :ab49[1]
+    lda #osfind_open_input                                            ; 4b49: a9 40       .@  :ab49[1]
     jsr osfind                                                        ; 4b4b: 20 ce ff     .. :ab4b[1]   ; Open file for input (A=64)
     tay                                                               ; 4b4e: a8          .   :ab4e[1]   ; A=file handle (or zero on failure)
     beq cab17                                                         ; 4b4f: f0 c6       ..  :ab4f[1]
@@ -7426,7 +7429,7 @@ cabbc
 
 sub_cabc5
     jsr sub_cac18                                                     ; 4bc5: 20 18 ac     .. :abc5[1]
-    lda #$80                                                          ; 4bc8: a9 80       ..  :abc8[1]
+    lda #osfind_open_output                                           ; 4bc8: a9 80       ..  :abc8[1]
     jsr osfind                                                        ; 4bca: 20 ce ff     .. :abca[1]   ; Open file for output (A=128)
     sta l00ab                                                         ; 4bcd: 85 ab       ..  :abcd[1]   ; A=file handle (or zero on failure)
 ; $4bcf referenced 1 time by $ac09
@@ -7665,7 +7668,7 @@ sub_c0542
 c0552
     jsr read_tube_r2_data                                             ; 4d2d: 20 c5 06     .. :0552[3]
     tay                                                               ; 4d30: a8          .   :0555[3]
-    lda #0                                                            ; 4d31: a9 00       ..  :0556[3]
+    lda #osfind_close                                                 ; 4d31: a9 00       ..  :0556[3]
     jsr osfind                                                        ; 4d33: 20 ce ff     .. :0558[3]   ; Close one or all files
     jmp c059c                                                         ; 4d36: 4c 9c 05    L.. :055b[3]
 
@@ -9033,7 +9036,7 @@ sub_cb5f2
     sta (l00b8),y                                                     ; 55fb: 91 b8       ..  :b5fb[1]
     pla                                                               ; 55fd: 68          h   :b5fd[1]
     tay                                                               ; 55fe: a8          .   :b5fe[1]
-    lda #0                                                            ; 55ff: a9 00       ..  :b5ff[1]
+    lda #osfind_close                                                 ; 55ff: a9 00       ..  :b5ff[1]
     jsr osfind                                                        ; 5601: 20 ce ff     .. :b601[1]   ; Close one or all files
     jmp cb82b                                                         ; 5604: 4c 2b b8    L+. :b604[1]
 
@@ -15014,6 +15017,15 @@ pydis_end
 }
 !if (osfile_save) != $00 {
     !error "Assertion failed: osfile_save == $00"
+}
+!if (osfind_close) != $00 {
+    !error "Assertion failed: osfind_close == $00"
+}
+!if (osfind_open_input) != $40 {
+    !error "Assertion failed: osfind_open_input == $40"
+}
+!if (osfind_open_output) != $80 {
+    !error "Assertion failed: osfind_open_output == $80"
 }
 !if (service_absolute_workspace_claimed) != $0a {
     !error "Assertion failed: service_absolute_workspace_claimed == $0a"

--- a/examples/known_good/dfs226b_acme.asm
+++ b/examples/known_good/dfs226b_acme.asm
@@ -7343,7 +7343,7 @@ cab35
 ; $4b3d referenced 1 time by $ab1d
 cab3d
     plp                                                               ; 4b3d: 28          (   :ab3d[1]
-    jsr osnewl                                                        ; 4b3e: 20 e7 ff     .. :ab3e[1]   ; Write newline (character 10)
+    jsr osnewl                                                        ; 4b3e: 20 e7 ff     .. :ab3e[1]   ; Write newline (characters 10 and 13)
 ; $4b41 referenced 2 times by $aba5, $abbf
 cab41
     lda #osfind_close                                                 ; 4b41: a9 00       ..  :ab41[1]
@@ -7395,7 +7395,7 @@ loop_cab80
 ; $4b93 referenced 1 time by $ab7e
 cab93
     jsr sub_caba9                                                     ; 4b93: 20 a9 ab     .. :ab93[1]
-    jsr osnewl                                                        ; 4b96: 20 e7 ff     .. :ab96[1]   ; Write newline (character 10)
+    jsr osnewl                                                        ; 4b96: 20 e7 ff     .. :ab96[1]   ; Write newline (characters 10 and 13)
     lda #8                                                            ; 4b99: a9 08       ..  :ab99[1]
     clc                                                               ; 4b9b: 18          .   :ab9b[1]
     adc l00a8                                                         ; 4b9c: 65 a8       e.  :ab9c[1]
@@ -10590,7 +10590,7 @@ cbeee
     ldy #$7f                                                          ; 5f03: a0 7f       ..  :bf03[1]
     jsr sub_cbf84                                                     ; 5f05: 20 84 bf     .. :bf05[1]
     bpl cbee8                                                         ; 5f08: 10 de       ..  :bf08[1]
-    jsr osnewl                                                        ; 5f0a: 20 e7 ff     .. :bf0a[1]   ; Write newline (character 10)
+    jsr osnewl                                                        ; 5f0a: 20 e7 ff     .. :bf0a[1]   ; Write newline (characters 10 and 13)
     ldx #0                                                            ; 5f0d: a2 00       ..  :bf0d[1]
     jsr sub_cbf7c                                                     ; 5f0f: 20 7c bf     |. :bf0f[1]
     lda #$fd                                                          ; 5f12: a9 fd       ..  :bf12[1]
@@ -10633,8 +10633,8 @@ cbf33
     jsr sub_cbf7c                                                     ; 5f43: 20 7c bf     |. :bf43[1]
 ; $5f46 referenced 1 time by $bf17
 cbf46
-    jsr osnewl                                                        ; 5f46: 20 e7 ff     .. :bf46[1]   ; Write newline (character 10)
-    jsr osnewl                                                        ; 5f49: 20 e7 ff     .. :bf49[1]   ; Write newline (character 10)
+    jsr osnewl                                                        ; 5f46: 20 e7 ff     .. :bf46[1]   ; Write newline (characters 10 and 13)
+    jsr osnewl                                                        ; 5f49: 20 e7 ff     .. :bf49[1]   ; Write newline (characters 10 and 13)
     jmp cbee8                                                         ; 5f4c: 4c e8 be    L.. :bf4c[1]
 
 ; $5f4f referenced 1 time by $bf7c

--- a/examples/known_good/dfs226b_beebasm.asm
+++ b/examples/known_good/dfs226b_beebasm.asm
@@ -17,6 +17,9 @@ osbyte_write_shadow_memory_use        = 114
 osfile_load                           = 255
 osfile_read_catalogue_info            = 5
 osfile_save                           = 0
+osfind_close                          = 0
+osfind_open_input                     = 64
+osfind_open_output                    = 128
 service_absolute_workspace_claimed    = 10
 service_boot                          = 3
 service_check_swr_presence            = 43
@@ -7331,7 +7334,7 @@ nmi_XXX5 = l0d1f+1
 ; &4b09 referenced 1 time by &ab02
 .cab09
     sta l00ab                                                         ; 4b09: 85 ab       ..  :ab09[1]
-    lda #&40 ; '@'                                                    ; 4b0b: a9 40       .@  :ab0b[1]
+    lda #osfind_open_input                                            ; 4b0b: a9 40       .@  :ab0b[1]
     jsr osfind                                                        ; 4b0d: 20 ce ff     .. :ab0d[1]   ; Open file for input (A=64)
     tay                                                               ; 4b10: a8          .   :ab10[1]   ; A=file handle (or zero on failure)
     lda #&0d                                                          ; 4b11: a9 0d       ..  :ab11[1]
@@ -7371,12 +7374,12 @@ nmi_XXX5 = l0d1f+1
     jsr osnewl                                                        ; 4b3e: 20 e7 ff     .. :ab3e[1]   ; Write newline (character 10)
 ; &4b41 referenced 2 times by &aba5, &abbf
 .cab41
-    lda #0                                                            ; 4b41: a9 00       ..  :ab41[1]
+    lda #osfind_close                                                 ; 4b41: a9 00       ..  :ab41[1]
     jmp osfind                                                        ; 4b43: 4c ce ff    L.. :ab43[1]   ; Close one or all files
 
 .sub_cab46
     jsr sub_cac18                                                     ; 4b46: 20 18 ac     .. :ab46[1]
-    lda #&40 ; '@'                                                    ; 4b49: a9 40       .@  :ab49[1]
+    lda #osfind_open_input                                            ; 4b49: a9 40       .@  :ab49[1]
     jsr osfind                                                        ; 4b4b: 20 ce ff     .. :ab4b[1]   ; Open file for input (A=64)
     tay                                                               ; 4b4e: a8          .   :ab4e[1]   ; A=file handle (or zero on failure)
     beq cab17                                                         ; 4b4f: f0 c6       ..  :ab4f[1]
@@ -7454,7 +7457,7 @@ nmi_XXX5 = l0d1f+1
 
 .sub_cabc5
     jsr sub_cac18                                                     ; 4bc5: 20 18 ac     .. :abc5[1]
-    lda #&80                                                          ; 4bc8: a9 80       ..  :abc8[1]
+    lda #osfind_open_output                                           ; 4bc8: a9 80       ..  :abc8[1]
     jsr osfind                                                        ; 4bca: 20 ce ff     .. :abca[1]   ; Open file for output (A=128)
     sta l00ab                                                         ; 4bcd: 85 ab       ..  :abcd[1]   ; A=file handle (or zero on failure)
 ; &4bcf referenced 1 time by &ac09
@@ -7695,7 +7698,7 @@ nmi_XXX5 = l0d1f+1
 .c0552
     jsr read_tube_r2_data                                             ; 4d2d: 20 c5 06     .. :0552[3]
     tay                                                               ; 4d30: a8          .   :0555[3]
-    lda #0                                                            ; 4d31: a9 00       ..  :0556[3]
+    lda #osfind_close                                                 ; 4d31: a9 00       ..  :0556[3]
     jsr osfind                                                        ; 4d33: 20 ce ff     .. :0558[3]   ; Close one or all files
     jmp c059c                                                         ; 4d36: 4c 9c 05    L.. :055b[3]
 
@@ -9069,7 +9072,7 @@ jump_address_low = sub_c0050+1
     sta (l00b8),y                                                     ; 55fb: 91 b8       ..  :b5fb[1]
     pla                                                               ; 55fd: 68          h   :b5fd[1]
     tay                                                               ; 55fe: a8          .   :b5fe[1]
-    lda #0                                                            ; 55ff: a9 00       ..  :b5ff[1]
+    lda #osfind_close                                                 ; 55ff: a9 00       ..  :b5ff[1]
     jsr osfind                                                        ; 5601: 20 ce ff     .. :b601[1]   ; Close one or all files
     jmp cb82b                                                         ; 5604: 4c 2b b8    L+. :b604[1]
 
@@ -14826,6 +14829,9 @@ lb6ce = sub_cb6cd+1
     assert osfile_load == &ff
     assert osfile_read_catalogue_info == &05
     assert osfile_save == &00
+    assert osfind_close == &00
+    assert osfind_open_input == &40
+    assert osfind_open_output == &80
     assert service_absolute_workspace_claimed == &0a
     assert service_boot == &03
     assert service_check_swr_presence == &2b

--- a/examples/known_good/dfs226b_beebasm.asm
+++ b/examples/known_good/dfs226b_beebasm.asm
@@ -7371,7 +7371,7 @@ nmi_XXX5 = l0d1f+1
 ; &4b3d referenced 1 time by &ab1d
 .cab3d
     plp                                                               ; 4b3d: 28          (   :ab3d[1]
-    jsr osnewl                                                        ; 4b3e: 20 e7 ff     .. :ab3e[1]   ; Write newline (character 10)
+    jsr osnewl                                                        ; 4b3e: 20 e7 ff     .. :ab3e[1]   ; Write newline (characters 10 and 13)
 ; &4b41 referenced 2 times by &aba5, &abbf
 .cab41
     lda #osfind_close                                                 ; 4b41: a9 00       ..  :ab41[1]
@@ -7423,7 +7423,7 @@ nmi_XXX5 = l0d1f+1
 ; &4b93 referenced 1 time by &ab7e
 .cab93
     jsr sub_caba9                                                     ; 4b93: 20 a9 ab     .. :ab93[1]
-    jsr osnewl                                                        ; 4b96: 20 e7 ff     .. :ab96[1]   ; Write newline (character 10)
+    jsr osnewl                                                        ; 4b96: 20 e7 ff     .. :ab96[1]   ; Write newline (characters 10 and 13)
     lda #8                                                            ; 4b99: a9 08       ..  :ab99[1]
     clc                                                               ; 4b9b: 18          .   :ab9b[1]
     adc l00a8                                                         ; 4b9c: 65 a8       e.  :ab9c[1]
@@ -10626,7 +10626,7 @@ lb6ce = sub_cb6cd+1
     ldy #&7f                                                          ; 5f03: a0 7f       ..  :bf03[1]
     jsr sub_cbf84                                                     ; 5f05: 20 84 bf     .. :bf05[1]
     bpl cbee8                                                         ; 5f08: 10 de       ..  :bf08[1]
-    jsr osnewl                                                        ; 5f0a: 20 e7 ff     .. :bf0a[1]   ; Write newline (character 10)
+    jsr osnewl                                                        ; 5f0a: 20 e7 ff     .. :bf0a[1]   ; Write newline (characters 10 and 13)
     ldx #0                                                            ; 5f0d: a2 00       ..  :bf0d[1]
     jsr sub_cbf7c                                                     ; 5f0f: 20 7c bf     |. :bf0f[1]
     lda #&fd                                                          ; 5f12: a9 fd       ..  :bf12[1]
@@ -10669,8 +10669,8 @@ lb6ce = sub_cb6cd+1
     jsr sub_cbf7c                                                     ; 5f43: 20 7c bf     |. :bf43[1]
 ; &5f46 referenced 1 time by &bf17
 .cbf46
-    jsr osnewl                                                        ; 5f46: 20 e7 ff     .. :bf46[1]   ; Write newline (character 10)
-    jsr osnewl                                                        ; 5f49: 20 e7 ff     .. :bf49[1]   ; Write newline (character 10)
+    jsr osnewl                                                        ; 5f46: 20 e7 ff     .. :bf46[1]   ; Write newline (characters 10 and 13)
+    jsr osnewl                                                        ; 5f49: 20 e7 ff     .. :bf49[1]   ; Write newline (characters 10 and 13)
     jmp cbee8                                                         ; 5f4c: 4c e8 be    L.. :bf4c[1]
 
 ; &5f4f referenced 1 time by &bf7c

--- a/examples/known_good/dfs226b_xa.asm
+++ b/examples/known_good/dfs226b_xa.asm
@@ -7332,7 +7332,7 @@ cab35
 // $4b3d referenced 1 time by $ab1d
 cab3d
     plp                                                               // 4b3d: 28          (   :ab3d[1]
-    jsr osnewl                                                        // 4b3e: 20 e7 ff     .. :ab3e[1]   // Write newline (character 10)
+    jsr osnewl                                                        // 4b3e: 20 e7 ff     .. :ab3e[1]   // Write newline (characters 10 and 13)
 // $4b41 referenced 2 times by $aba5, $abbf
 cab41
     lda #osfind_close                                                 // 4b41: a9 00       ..  :ab41[1]
@@ -7384,7 +7384,7 @@ loop_cab80
 // $4b93 referenced 1 time by $ab7e
 cab93
     jsr sub_caba9                                                     // 4b93: 20 a9 ab     .. :ab93[1]
-    jsr osnewl                                                        // 4b96: 20 e7 ff     .. :ab96[1]   // Write newline (character 10)
+    jsr osnewl                                                        // 4b96: 20 e7 ff     .. :ab96[1]   // Write newline (characters 10 and 13)
     lda #8                                                            // 4b99: a9 08       ..  :ab99[1]
     clc                                                               // 4b9b: 18          .   :ab9b[1]
     adc l00a8                                                         // 4b9c: 65 a8       e.  :ab9c[1]
@@ -10567,7 +10567,7 @@ cbeee
     ldy #$7f                                                          // 5f03: a0 7f       ..  :bf03[1]
     jsr sub_cbf84                                                     // 5f05: 20 84 bf     .. :bf05[1]
     bpl cbee8                                                         // 5f08: 10 de       ..  :bf08[1]
-    jsr osnewl                                                        // 5f0a: 20 e7 ff     .. :bf0a[1]   // Write newline (character 10)
+    jsr osnewl                                                        // 5f0a: 20 e7 ff     .. :bf0a[1]   // Write newline (characters 10 and 13)
     ldx #0                                                            // 5f0d: a2 00       ..  :bf0d[1]
     jsr sub_cbf7c                                                     // 5f0f: 20 7c bf     |. :bf0f[1]
     lda #$fd                                                          // 5f12: a9 fd       ..  :bf12[1]
@@ -10610,8 +10610,8 @@ cbf33
     jsr sub_cbf7c                                                     // 5f43: 20 7c bf     |. :bf43[1]
 // $5f46 referenced 1 time by $bf17
 cbf46
-    jsr osnewl                                                        // 5f46: 20 e7 ff     .. :bf46[1]   // Write newline (character 10)
-    jsr osnewl                                                        // 5f49: 20 e7 ff     .. :bf49[1]   // Write newline (character 10)
+    jsr osnewl                                                        // 5f46: 20 e7 ff     .. :bf46[1]   // Write newline (characters 10 and 13)
+    jsr osnewl                                                        // 5f49: 20 e7 ff     .. :bf49[1]   // Write newline (characters 10 and 13)
     jmp cbee8                                                         // 5f4c: 4c e8 be    L.. :bf4c[1]
 
 // $5f4f referenced 1 time by $bf7c

--- a/examples/known_good/dfs226b_xa.asm
+++ b/examples/known_good/dfs226b_xa.asm
@@ -17,6 +17,9 @@ osbyte_write_shadow_memory_use        = 114
 osfile_load                           = 255
 osfile_read_catalogue_info            = 5
 osfile_save                           = 0
+osfind_close                          = 0
+osfind_open_input                     = 64
+osfind_open_output                    = 128
 service_absolute_workspace_claimed    = 10
 service_boot                          = 3
 service_check_swr_presence            = 43
@@ -7292,7 +7295,7 @@ sub_cab04
 // $4b09 referenced 1 time by $ab02
 cab09
     sta l00ab                                                         // 4b09: 85 ab       ..  :ab09[1]
-    lda #$40 // '@'                                                   // 4b0b: a9 40       .@  :ab0b[1]
+    lda #osfind_open_input                                            // 4b0b: a9 40       .@  :ab0b[1]
     jsr osfind                                                        // 4b0d: 20 ce ff     .. :ab0d[1]   // Open file for input (A=64)
     tay                                                               // 4b10: a8          .   :ab10[1]   // A=file handle (or zero on failure)
     lda #$0d                                                          // 4b11: a9 0d       ..  :ab11[1]
@@ -7332,12 +7335,12 @@ cab3d
     jsr osnewl                                                        // 4b3e: 20 e7 ff     .. :ab3e[1]   // Write newline (character 10)
 // $4b41 referenced 2 times by $aba5, $abbf
 cab41
-    lda #0                                                            // 4b41: a9 00       ..  :ab41[1]
+    lda #osfind_close                                                 // 4b41: a9 00       ..  :ab41[1]
     jmp osfind                                                        // 4b43: 4c ce ff    L.. :ab43[1]   // Close one or all files
 
 sub_cab46
     jsr sub_cac18                                                     // 4b46: 20 18 ac     .. :ab46[1]
-    lda #$40 // '@'                                                   // 4b49: a9 40       .@  :ab49[1]
+    lda #osfind_open_input                                            // 4b49: a9 40       .@  :ab49[1]
     jsr osfind                                                        // 4b4b: 20 ce ff     .. :ab4b[1]   // Open file for input (A=64)
     tay                                                               // 4b4e: a8          .   :ab4e[1]   // A=file handle (or zero on failure)
     beq cab17                                                         // 4b4f: f0 c6       ..  :ab4f[1]
@@ -7415,7 +7418,7 @@ cabbc
 
 sub_cabc5
     jsr sub_cac18                                                     // 4bc5: 20 18 ac     .. :abc5[1]
-    lda #$80                                                          // 4bc8: a9 80       ..  :abc8[1]
+    lda #osfind_open_output                                           // 4bc8: a9 80       ..  :abc8[1]
     jsr osfind                                                        // 4bca: 20 ce ff     .. :abca[1]   // Open file for output (A=128)
     sta l00ab                                                         // 4bcd: 85 ab       ..  :abcd[1]   // A=file handle (or zero on failure)
 // $4bcf referenced 1 time by $ac09
@@ -7652,7 +7655,7 @@ sub_c0542
 c0552
     jsr read_tube_r2_data                                             // 4d2d: 20 c5 06     .. :0552[3]
     tay                                                               // 4d30: a8          .   :0555[3]
-    lda #0                                                            // 4d31: a9 00       ..  :0556[3]
+    lda #osfind_close                                                 // 4d31: a9 00       ..  :0556[3]
     jsr osfind                                                        // 4d33: 20 ce ff     .. :0558[3]   // Close one or all files
     jmp c059c                                                         // 4d36: 4c 9c 05    L.. :055b[3]
 
@@ -9010,7 +9013,7 @@ sub_cb5f2
     sta (l00b8),y                                                     // 55fb: 91 b8       ..  :b5fb[1]
     pla                                                               // 55fd: 68          h   :b5fd[1]
     tay                                                               // 55fe: a8          .   :b5fe[1]
-    lda #0                                                            // 55ff: a9 00       ..  :b5ff[1]
+    lda #osfind_close                                                 // 55ff: a9 00       ..  :b5ff[1]
     jsr osfind                                                        // 5601: 20 ce ff     .. :b601[1]   // Close one or all files
     jmp cb82b                                                         // 5604: 4c 2b b8    L+. :b604[1]
 

--- a/py8dis/acorn.py
+++ b/py8dis/acorn.py
@@ -376,7 +376,7 @@ osbyte_enum = {
     0xbd: "osbyte_read_write_max_adc_channel",
     0xbe: "osbyte_read_write_adc_conversion_type",
     0xbf: "osbyte_read_write_serial_user_flag",
-    0xc0: "osbyte_read_serial_control_flag",
+    0xc0: "osbyte_read_serial_control_register_copy",
     0xc1: "osbyte_read_write_flash_counter",
     0xc2: "osbyte_read_write_mark_count",
     0xc3: "osbyte_read_write_space_count",
@@ -405,16 +405,16 @@ osbyte_enum = {
     0xda: "osbyte_read_write_vdu_queue_size",
     0xdb: "osbyte_read_write_tab_char",
     0xdc: "osbyte_read_write_escape_char",
-    0xdd: "osbyte_read_write_c0_cf_status",
-    0xde: "osbyte_read_write_d0_df_status",
-    0xdf: "osbyte_read_write_e0_ef_status",
-    0xe0: "osbyte_read_write_f0_ff_status",
+    0xdd: "osbyte_read_write_characters_c0_cf_status",
+    0xde: "osbyte_read_write_characters_d0_df_status",
+    0xdf: "osbyte_read_write_characters_e0_ef_status",
+    0xe0: "osbyte_read_write_characters_f0_ff_status",
     0xe1: "osbyte_read_write_function_key_status",
     0xe2: "osbyte_read_write_shift_function_key_status",
     0xe3: "osbyte_read_write_ctrl_function_key_status",
     0xe4: "osbyte_read_write_ctrl_shift_function_key_status",
     0xe5: "osbyte_read_write_escape_status",
-    0xe6: "osbyte_read_write_escape_flags",
+    0xe6: "osbyte_read_write_escape_effects",
     0xe7: "osbyte_read_write_user_via_irq_mask",
     0xe8: "osbyte_read_write_6850_irq_mark",
     0xe9: "osbyte_read_write_system_via_irq_mask",
@@ -429,7 +429,7 @@ osbyte_enum = {
     0xf2: "osbyte_read_serial_ula",
     0xf3: "osbyte_read_write_timer_switch_state",
     0xf4: "osbyte_read_write_soft_key_consistency_flag",
-    0xf5: "osbyte_read_write_printer_destination_flag",
+    0xf5: "osbyte_read_write_printer_destination",
     0xf6: "osbyte_read_write_printer_ignore_char",
     0xf7: "osbyte_read_write_first_byte_break_intercept",
     0xf8: "osbyte_read_write_second_byte_break_intercept",
@@ -2469,6 +2469,11 @@ def osbyte_hook(runtime_addr, state, subroutine):
                     name = "Set ESCAPE key to produce ASCII code " + str(write_value)
                 auto_comment(runtime_addr, name, inline=True)
                 skip_normal_comment = True
+            elif action == 0xff:
+                # If writing the startup byte, show it in binary
+                if write_value is not None:
+                    if x_runtime_addr is not None:
+                        binary(x_runtime_addr)
 
             if not skip_normal_comment:
                 com = format_osbyte_rw(x_addr, y_addr, name)

--- a/py8dis/acorn.py
+++ b/py8dis/acorn.py
@@ -1256,7 +1256,7 @@ def osargs_hook(runtime_addr, state, subroutine):
         auto_comment(runtime_addr, "Read or write a file's attributes", inline=True)
 
 def osnewl_hook(runtime_addr, state, subroutine):
-    auto_comment(runtime_addr, "Write newline (character 10)", inline=True)
+    auto_comment(runtime_addr, "Write newline (characters 10 and 13)", inline=True)
 
 def oswrcr_hook(runtime_addr, state, subroutine):
     auto_comment(runtime_addr, "Write carriage return (character 13)", inline=True)


### PR DESCRIPTION
Expression making is implemented, used for building up expression strings in an assembler agnostic manner. It can take integers, strings, and LazyStrings. See `README.md` for documentation.

Added `auto_enum()`, and used it throughout acorn.py. I've added constants for osfind types, buffer numbers, event types, baud rates, and keys. These ones made the most sense to me to have as enums / constants wrt #21. The keys are interesting as they make use of the new expression making:

```
     lda #osbyte_scan_keyboard                  
     ldx #(255 - inkey_key_shift) XOR 128            ; X=internal key number EOR 128
     jsr osbyte                                      ; Test for 'SHIFT' key pressed (X=128)
```