### PR TITLE
Make some comments not inline

### DIFF
--- a/examples/known_good/anfs418_acme.asm
+++ b/examples/known_good/anfs418_acme.asm
@@ -350,7 +350,8 @@ sub_c8028
 
 ; $8032 referenced 1 time by $802d
 c8032
-    txa                                                               ; 8032: 8a          .              ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; 8032: 8a          .
     pha                                                               ; 8033: 48          H
     tya                                                               ; 8034: 98          .
     pha                                                               ; 8035: 48          H
@@ -1154,7 +1155,8 @@ return_4
 
 ; $8585 referenced 1 time by $8057
 c8585
-    pla                                                               ; 8585: 68          h              ; pull X,Y from the stack
+    ; pull X,Y from the stack
+    pla                                                               ; 8585: 68          h
     tay                                                               ; 8586: a8          .
     pla                                                               ; 8587: 68          h
     tax                                                               ; 8588: aa          .
@@ -1834,7 +1836,8 @@ c89a4
 ; $89a6 referenced 1 time by $8096
 sub_c89a7
     bit station_id_disable_net_nmis                                   ; 89a7: 2c 18 fe    ,..
-    pha                                                               ; 89aa: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 89aa: 48          H
     tya                                                               ; 89ab: 98          .
     pha                                                               ; 89ac: 48          H
     lda #0                                                            ; 89ad: a9 00       ..
@@ -1845,7 +1848,8 @@ sub_c89a7
     sta l0d0c                                                         ; 89b8: 8d 0c 0d    ...
     lda romsel_copy                                                   ; 89bb: a5 f4       ..
     sta romsel                                                        ; 89bd: 8d 30 fe    .0.
-    pla                                                               ; 89c0: 68          h              ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 89c0: 68          h
     tay                                                               ; 89c1: a8          .
     pla                                                               ; 89c2: 68          h
     bit video_ula_control                                             ; 89c3: 2c 20 fe    , .
@@ -1968,7 +1972,8 @@ c8a33
 ; $8a38 referenced 2 times by $8a25, $8a29
 c8a38
     ldx romsel_copy                                                   ; 8a38: a6 f4       ..
-    pla                                                               ; 8a3a: 68          h              ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 8a3a: 68          h
     tay                                                               ; 8a3b: a8          .
 ; $8a3c referenced 1 time by $8a18
 service_handler_common1
@@ -2209,12 +2214,14 @@ sub_c8b96
 ; $8b98 referenced 2 times by $8b8f, $8b94
 c8b98
     bvc c8ba8                                                         ; 8b98: 50 0e       P.
-    txa                                                               ; 8b9a: 8a          .              ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; 8b9a: 8a          .
     pha                                                               ; 8b9b: 48          H
     tya                                                               ; 8b9c: 98          .
     pha                                                               ; 8b9d: 48          H
     jsr sub_c8c9f                                                     ; 8b9e: 20 9f 8c     ..
-    pla                                                               ; 8ba1: 68          h              ; pull X,Y from the stack
+    ; pull X,Y from the stack
+    pla                                                               ; 8ba1: 68          h
     tay                                                               ; 8ba2: a8          .
     pla                                                               ; 8ba3: 68          h
     tax                                                               ; 8ba4: aa          .
@@ -2912,7 +2919,8 @@ return_11
 ; $8fcb referenced 5 times by $9bbe, $9d4e, $9dee, $9e2f, $b5fb
 sub_c8fcb
     php                                                               ; 8fcb: 08          .
-    pha                                                               ; 8fcc: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 8fcc: 48          H
     tya                                                               ; 8fcd: 98          .
     pha                                                               ; 8fce: 48          H
     ldy #$76 ; 'v'                                                    ; 8fcf: a0 76       .v
@@ -2926,7 +2934,8 @@ loop_c8fd4
     ldy #$77 ; 'w'                                                    ; 8fd9: a0 77       .w
     cmp (l00cc),y                                                     ; 8fdb: d1 cc       ..
     bne c8fe4                                                         ; 8fdd: d0 05       ..
-    pla                                                               ; 8fdf: 68          h              ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 8fdf: 68          h
     tay                                                               ; 8fe0: a8          .
     pla                                                               ; 8fe1: 68          h
     plp                                                               ; 8fe2: 28          (
@@ -3281,7 +3290,8 @@ sub_c92b0
 
 ; $92b5 referenced 2 times by $9c48, $9e8f
 sub_c92b5
-    php                                                               ; 92b5: 08          .              ; push flags,A,X onto the stack
+    ; push flags,A,X onto the stack
+    php                                                               ; 92b5: 08          .
     pha                                                               ; 92b6: 48          H
     txa                                                               ; 92b7: 8a          .
     pha                                                               ; 92b8: 48          H
@@ -3295,7 +3305,8 @@ sub_c92b5
     bne c92e1                                                         ; 92ca: d0 15       ..
 ; $92cc referenced 2 times by $9ca9, $9e8a
 sub_c92cc
-    php                                                               ; 92cc: 08          .              ; push flags,A,X onto the stack
+    ; push flags,A,X onto the stack
+    php                                                               ; 92cc: 08          .
     pha                                                               ; 92cd: 48          H
     txa                                                               ; 92ce: 8a          .
     pha                                                               ; 92cf: 48          H
@@ -3308,7 +3319,8 @@ sub_c92cc
     sta l1060,x                                                       ; 92de: 9d 60 10    .`.
 ; $92e1 referenced 3 times by $92c0, $92ca, $92d7
 c92e1
-    pla                                                               ; 92e1: 68          h              ; pull flags,A,X from the stack
+    ; pull flags,A,X from the stack
+    pla                                                               ; 92e1: 68          h
     tax                                                               ; 92e2: aa          .
     pla                                                               ; 92e3: 68          h
     plp                                                               ; 92e4: 28          (
@@ -3466,7 +3478,8 @@ c93bc
     txa                                                               ; 93cd: 8a          .
     pha                                                               ; 93ce: 48          H
     jsr sub_cae97                                                     ; 93cf: 20 97 ae     ..
-    pla                                                               ; 93d2: 68          h              ; pull A,X from the stack
+    ; pull A,X from the stack
+    pla                                                               ; 93d2: 68          h
     tax                                                               ; 93d3: aa          .
     pla                                                               ; 93d4: 68          h
     cmp l1071                                                         ; 93d5: cd 71 10    .q.
@@ -4027,7 +4040,8 @@ c96fa
 ; $96fd referenced 1 time by $96f3
 c96fd
     sta l0e08                                                         ; 96fd: 8d 08 0e    ...
-    pha                                                               ; 9700: 48          H              ; push A,X onto the stack
+    ; push A,X onto the stack
+    pha                                                               ; 9700: 48          H
     txa                                                               ; 9701: 8a          .
     pha                                                               ; 9702: 48          H
     jsr sub_cb98a                                                     ; 9703: 20 8a b9     ..
@@ -4191,7 +4205,8 @@ c983f
 ; $9846 referenced 1 time by $9842
 c9846
     ldy #$60 ; '`'                                                    ; 9846: a0 60       .`
-    pha                                                               ; 9848: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 9848: 48          H
     tya                                                               ; 9849: 98          .              ; A=$60
     pha                                                               ; 984a: 48          H
     ldx #0                                                            ; 984b: a2 00       ..
@@ -4206,7 +4221,8 @@ c984f
     asl                                                               ; 9858: 0a          .
     beq c987e                                                         ; 9859: f0 23       .#
     jsr sub_c9570                                                     ; 985b: 20 70 95     p.
-    pla                                                               ; 985e: 68          h              ; pull A,Y,X from the stack
+    ; pull A,Y,X from the stack
+    pla                                                               ; 985e: 68          h
     tax                                                               ; 985f: aa          .
     pla                                                               ; 9860: 68          h
     tay                                                               ; 9861: a8          .
@@ -4215,7 +4231,8 @@ c984f
 ; $9865 referenced 1 time by $987c
 loop_c9865
     sbc #1                                                            ; 9865: e9 01       ..
-    pha                                                               ; 9867: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 9867: 48          H
     tya                                                               ; 9868: 98          .
     pha                                                               ; 9869: 48          H
     txa                                                               ; 986a: 8a          .
@@ -4274,7 +4291,8 @@ c98ab
     dey                                                               ; 98ab: 88          .
     bpl loop_c989e                                                    ; 98ac: 10 f0       ..
     lda l0d6f                                                         ; 98ae: ad 6f 0d    .o.
-    pha                                                               ; 98b1: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 98b1: 48          H
     tya                                                               ; 98b2: 98          .
     pha                                                               ; 98b3: 48          H
     ldx #0                                                            ; 98b4: a2 00       ..
@@ -4310,14 +4328,16 @@ loop_c98d9
 
 ; $98de referenced 1 time by $98c2
 c98de
-    pla                                                               ; 98de: 68          h              ; pull A,Y,X from the stack
+    ; pull A,Y,X from the stack
+    pla                                                               ; 98de: 68          h
     tax                                                               ; 98df: aa          .
     pla                                                               ; 98e0: 68          h
     tay                                                               ; 98e1: a8          .
     pla                                                               ; 98e2: 68          h
     beq loop_c98c4                                                    ; 98e3: f0 df       ..
     sbc #1                                                            ; 98e5: e9 01       ..
-    pha                                                               ; 98e7: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 98e7: 48          H
     tya                                                               ; 98e8: 98          .
     pha                                                               ; 98e9: 48          H
     txa                                                               ; 98ea: 8a          .
@@ -4892,7 +4912,8 @@ c9bf8
 
 ; $9c03 referenced 1 time by $9bfe
 c9c03
-    pha                                                               ; 9c03: 48          H              ; push A,X,Y onto the stack
+    ; push A,X,Y onto the stack
+    pha                                                               ; 9c03: 48          H
     txa                                                               ; 9c04: 8a          .
     pha                                                               ; 9c05: 48          H
     tya                                                               ; 9c06: 98          .
@@ -4902,7 +4923,8 @@ c9c03
     jsr sub_cb98f                                                     ; 9c0c: 20 8f b9     ..
     lda l1030,x                                                       ; 9c0f: bd 30 10    .0.
     sta l0f05                                                         ; 9c12: 8d 05 0f    ...
-    pla                                                               ; 9c15: 68          h              ; pull A,X from the stack
+    ; pull A,X from the stack
+    pla                                                               ; 9c15: 68          h
     tax                                                               ; 9c16: aa          .
     pla                                                               ; 9c17: 68          h
     lsr                                                               ; 9c18: 4a          J
@@ -5220,7 +5242,8 @@ c9e09
     ldx #0                                                            ; 9e09: a2 00       ..
 ; $9e0b referenced 1 time by $9e07
 c9e0b
-    pla                                                               ; 9e0b: 68          h              ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 9e0b: 68          h
     tay                                                               ; 9e0c: a8          .
     pla                                                               ; 9e0d: 68          h
     rts                                                               ; 9e0e: 60          `
@@ -6964,7 +6987,8 @@ sub_ca976
     cli                                                               ; a976: 58          X
     jmp c983f                                                         ; a977: 4c 3f 98    L?.
 
-    php                                                               ; a97a: 08          .              ; push flags,A,X,Y onto the stack
+    ; push flags,A,X,Y onto the stack
+    php                                                               ; a97a: 08          .
     pha                                                               ; a97b: 48          H
     txa                                                               ; a97c: 8a          .
     pha                                                               ; a97d: 48          H
@@ -6978,7 +7002,8 @@ sub_ca976
     jsr sub_ca993                                                     ; a989: 20 93 a9     ..
 ; $a98c referenced 1 time by $a986
 ca98c
-    pla                                                               ; a98c: 68          h              ; pull flags,A,X,Y from the stack
+    ; pull flags,A,X,Y from the stack
+    pla                                                               ; a98c: 68          h
     tay                                                               ; a98d: a8          .
     pla                                                               ; a98e: 68          h
     tax                                                               ; a98f: aa          .
@@ -9281,7 +9306,8 @@ return_38
 
 ; $b799 referenced 8 times by $8d87, $8fa0, $94a0, $9bdc, $9c21, $9cc4, $9d8a, $9e58
 sub_cb799
-    txa                                                               ; b799: 8a          .              ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; b799: 8a          .
     pha                                                               ; b79a: 48          H
     tya                                                               ; b79b: 98          .
     pha                                                               ; b79c: 48          H
@@ -9318,7 +9344,8 @@ loop_cb7c3
     sta l00b4,x                                                       ; b7c4: 95 b4       ..
     dex                                                               ; b7c6: ca          .
     bpl loop_cb7c3                                                    ; b7c7: 10 fa       ..
-    pla                                                               ; b7c9: 68          h              ; pull X,Y from the stack
+    ; pull X,Y from the stack
+    pla                                                               ; b7c9: 68          h
     tay                                                               ; b7ca: a8          .
     pla                                                               ; b7cb: 68          h
     tax                                                               ; b7cc: aa          .
@@ -9337,7 +9364,8 @@ loop_cb7c3
     !byte $b3, $a9,   0, $85, $b2, $68, $aa, $b1, $b2, $ac, $c9, $10  ; b83f: b3 a9 00... ...
     !byte $18, $60, $8c, $c9, $10, $48, $a8                           ; b84b: 18 60 8c... .`.
 
-    txa                                                               ; b852: 8a          .              ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; b852: 8a          .
     pha                                                               ; b853: 48          H
     tya                                                               ; b854: 98          .
     pha                                                               ; b855: 48          H
@@ -9400,7 +9428,8 @@ cb8cb
     jsr sub_cb78b                                                     ; b8cb: 20 8b b7     ..
     lda #0                                                            ; b8ce: a9 00       ..
     jsr sub_cb98f                                                     ; b8d0: 20 8f b9     ..
-    pla                                                               ; b8d3: 68          h              ; pull A,X from the stack
+    ; pull A,X from the stack
+    pla                                                               ; b8d3: 68          h
     tax                                                               ; b8d4: aa          .
     pla                                                               ; b8d5: 68          h
     ldy l10c9                                                         ; b8d6: ac c9 10    ...
@@ -9408,7 +9437,8 @@ cb8cb
 
 ; $b8da referenced 1 time by $b6c3
 sub_cb8da
-    pha                                                               ; b8da: 48          H              ; push A,X,Y onto the stack
+    ; push A,X,Y onto the stack
+    pha                                                               ; b8da: 48          H
     txa                                                               ; b8db: 8a          .
     pha                                                               ; b8dc: 48          H
     tya                                                               ; b8dd: 98          .
@@ -9417,7 +9447,8 @@ sub_cb8da
     bne cb8f3                                                         ; b8e2: d0 0f       ..
 ; $b8e4 referenced 1 time by $b895
 sub_cb8e4
-    pha                                                               ; b8e4: 48          H              ; push A,X,Y onto the stack
+    ; push A,X,Y onto the stack
+    pha                                                               ; b8e4: 48          H
     txa                                                               ; b8e5: 8a          .
     pha                                                               ; b8e6: 48          H
     tya                                                               ; b8e7: 98          .
@@ -9433,7 +9464,8 @@ cb8f3
     tax                                                               ; b8f6: aa          .
     pla                                                               ; b8f7: 68          h
     tay                                                               ; b8f8: a8          .
-    pha                                                               ; b8f9: 48          H              ; push A,X onto the stack
+    ; push A,X onto the stack
+    pha                                                               ; b8f9: 48          H
     txa                                                               ; b8fa: 8a          .
     pha                                                               ; b8fb: 48          H
     ldx #0                                                            ; b8fc: a2 00       ..
@@ -9452,7 +9484,8 @@ cb8f3
     lda l10d7                                                         ; b91c: ad d7 10    ...
     jsr sub_cb92b                                                     ; b91f: 20 2b b9     +.
     jsr sub_cb721                                                     ; b922: 20 21 b7     !.
-    pla                                                               ; b925: 68          h              ; pull A,X,Y from the stack
+    ; pull A,X,Y from the stack
+    pla                                                               ; b925: 68          h
     tay                                                               ; b926: a8          .
     pla                                                               ; b927: 68          h
     tax                                                               ; b928: aa          .
@@ -9463,7 +9496,8 @@ cb8f3
 sub_cb92b
     sty l0fde                                                         ; b92b: 8c de 0f    ...
     sta l0fdf                                                         ; b92e: 8d df 0f    ...
-    tya                                                               ; b931: 98          .              ; push Y,X onto the stack
+    ; push Y,X onto the stack
+    tya                                                               ; b931: 98          .
     pha                                                               ; b932: 48          H
     txa                                                               ; b933: 8a          .
     pha                                                               ; b934: 48          H
@@ -9505,7 +9539,8 @@ cb974
     lda l1040,x                                                       ; b977: bd 40 10    .@.
     eor #1                                                            ; b97a: 49 01       I.
     sta l1040,x                                                       ; b97c: 9d 40 10    .@.
-    pla                                                               ; b97f: 68          h              ; pull Y,X from the stack
+    ; pull Y,X from the stack
+    pla                                                               ; b97f: 68          h
     tax                                                               ; b980: aa          .
     pla                                                               ; b981: 68          h
     tay                                                               ; b982: a8          .
@@ -9835,7 +9870,8 @@ cbb1a
 ; $bb39 referenced 1 time by $bb2d
 cbb39
     and #$0f                                                          ; bb39: 29 0f       ).
-    pha                                                               ; bb3b: 48          H              ; push A,X onto the stack
+    ; push A,X onto the stack
+    pha                                                               ; bb3b: 48          H
     txa                                                               ; bb3c: 8a          .
     pha                                                               ; bb3d: 48          H
     ldx #4                                                            ; bb3e: a2 04       ..
@@ -9860,7 +9896,8 @@ loop_cbb43
     bcs cbb64                                                         ; bb53: b0 0f       ..
     dex                                                               ; bb55: ca          .
     bne loop_cbb40                                                    ; bb56: d0 e8       ..
-    pla                                                               ; bb58: 68          h              ; pull A,X from the stack
+    ; pull A,X from the stack
+    pla                                                               ; bb58: 68          h
     tax                                                               ; bb59: aa          .
     pla                                                               ; bb5a: 68          h
     ldy #0                                                            ; bb5b: a0 00       ..

--- a/examples/known_good/anfs418_beebasm.asm
+++ b/examples/known_good/anfs418_beebasm.asm
@@ -350,7 +350,8 @@ l8004 = service_entry+1
 
 ; &8032 referenced 1 time by &802d
 .c8032
-    txa                                                               ; 8032: 8a          .              ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; 8032: 8a          .
     pha                                                               ; 8033: 48          H
     tya                                                               ; 8034: 98          .
     pha                                                               ; 8035: 48          H
@@ -1154,7 +1155,8 @@ l8004 = service_entry+1
 
 ; &8585 referenced 1 time by &8057
 .c8585
-    pla                                                               ; 8585: 68          h              ; pull X,Y from the stack
+    ; pull X,Y from the stack
+    pla                                                               ; 8585: 68          h
     tay                                                               ; 8586: a8          .
     pla                                                               ; 8587: 68          h
     tax                                                               ; 8588: aa          .
@@ -1834,7 +1836,8 @@ l8869 = c8868+1
 ; &89a6 referenced 1 time by &8096
 .sub_c89a7
     bit station_id_disable_net_nmis                                   ; 89a7: 2c 18 fe    ,..
-    pha                                                               ; 89aa: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 89aa: 48          H
     tya                                                               ; 89ab: 98          .
     pha                                                               ; 89ac: 48          H
     lda #0                                                            ; 89ad: a9 00       ..
@@ -1845,7 +1848,8 @@ l8869 = c8868+1
     sta l0d0c                                                         ; 89b8: 8d 0c 0d    ...
     lda romsel_copy                                                   ; 89bb: a5 f4       ..
     sta romsel                                                        ; 89bd: 8d 30 fe    .0.
-    pla                                                               ; 89c0: 68          h              ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 89c0: 68          h
     tay                                                               ; 89c1: a8          .
     pla                                                               ; 89c2: 68          h
     bit video_ula_control                                             ; 89c3: 2c 20 fe    , .
@@ -1968,7 +1972,8 @@ l8869 = c8868+1
 ; &8a38 referenced 2 times by &8a25, &8a29
 .c8a38
     ldx romsel_copy                                                   ; 8a38: a6 f4       ..
-    pla                                                               ; 8a3a: 68          h              ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 8a3a: 68          h
     tay                                                               ; 8a3b: a8          .
 ; &8a3c referenced 1 time by &8a18
 .service_handler_common1
@@ -2209,12 +2214,14 @@ l8869 = c8868+1
 ; &8b98 referenced 2 times by &8b8f, &8b94
 .c8b98
     bvc c8ba8                                                         ; 8b98: 50 0e       P.
-    txa                                                               ; 8b9a: 8a          .              ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; 8b9a: 8a          .
     pha                                                               ; 8b9b: 48          H
     tya                                                               ; 8b9c: 98          .
     pha                                                               ; 8b9d: 48          H
     jsr sub_c8c9f                                                     ; 8b9e: 20 9f 8c     ..
-    pla                                                               ; 8ba1: 68          h              ; pull X,Y from the stack
+    ; pull X,Y from the stack
+    pla                                                               ; 8ba1: 68          h
     tay                                                               ; 8ba2: a8          .
     pla                                                               ; 8ba3: 68          h
     tax                                                               ; 8ba4: aa          .
@@ -2912,7 +2919,8 @@ l8e54 = sub_c8e52+2
 ; &8fcb referenced 5 times by &9bbe, &9d4e, &9dee, &9e2f, &b5fb
 .sub_c8fcb
     php                                                               ; 8fcb: 08          .
-    pha                                                               ; 8fcc: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 8fcc: 48          H
     tya                                                               ; 8fcd: 98          .
     pha                                                               ; 8fce: 48          H
     ldy #&76 ; 'v'                                                    ; 8fcf: a0 76       .v
@@ -2926,7 +2934,8 @@ l8e54 = sub_c8e52+2
     ldy #&77 ; 'w'                                                    ; 8fd9: a0 77       .w
     cmp (l00cc),y                                                     ; 8fdb: d1 cc       ..
     bne c8fe4                                                         ; 8fdd: d0 05       ..
-    pla                                                               ; 8fdf: 68          h              ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 8fdf: 68          h
     tay                                                               ; 8fe0: a8          .
     pla                                                               ; 8fe1: 68          h
     plp                                                               ; 8fe2: 28          (
@@ -3281,7 +3290,8 @@ l8e54 = sub_c8e52+2
 
 ; &92b5 referenced 2 times by &9c48, &9e8f
 .sub_c92b5
-    php                                                               ; 92b5: 08          .              ; push flags,A,X onto the stack
+    ; push flags,A,X onto the stack
+    php                                                               ; 92b5: 08          .
     pha                                                               ; 92b6: 48          H
     txa                                                               ; 92b7: 8a          .
     pha                                                               ; 92b8: 48          H
@@ -3295,7 +3305,8 @@ l8e54 = sub_c8e52+2
     bne c92e1                                                         ; 92ca: d0 15       ..
 ; &92cc referenced 2 times by &9ca9, &9e8a
 .sub_c92cc
-    php                                                               ; 92cc: 08          .              ; push flags,A,X onto the stack
+    ; push flags,A,X onto the stack
+    php                                                               ; 92cc: 08          .
     pha                                                               ; 92cd: 48          H
     txa                                                               ; 92ce: 8a          .
     pha                                                               ; 92cf: 48          H
@@ -3308,7 +3319,8 @@ l8e54 = sub_c8e52+2
     sta l1060,x                                                       ; 92de: 9d 60 10    .`.
 ; &92e1 referenced 3 times by &92c0, &92ca, &92d7
 .c92e1
-    pla                                                               ; 92e1: 68          h              ; pull flags,A,X from the stack
+    ; pull flags,A,X from the stack
+    pla                                                               ; 92e1: 68          h
     tax                                                               ; 92e2: aa          .
     pla                                                               ; 92e3: 68          h
     plp                                                               ; 92e4: 28          (
@@ -3466,7 +3478,8 @@ l8e54 = sub_c8e52+2
     txa                                                               ; 93cd: 8a          .
     pha                                                               ; 93ce: 48          H
     jsr sub_cae97                                                     ; 93cf: 20 97 ae     ..
-    pla                                                               ; 93d2: 68          h              ; pull A,X from the stack
+    ; pull A,X from the stack
+    pla                                                               ; 93d2: 68          h
     tax                                                               ; 93d3: aa          .
     pla                                                               ; 93d4: 68          h
     cmp l1071                                                         ; 93d5: cd 71 10    .q.
@@ -4027,7 +4040,8 @@ error_template_minus_1 = sub_c96b3+1
 ; &96fd referenced 1 time by &96f3
 .c96fd
     sta l0e08                                                         ; 96fd: 8d 08 0e    ...
-    pha                                                               ; 9700: 48          H              ; push A,X onto the stack
+    ; push A,X onto the stack
+    pha                                                               ; 9700: 48          H
     txa                                                               ; 9701: 8a          .
     pha                                                               ; 9702: 48          H
     jsr sub_cb98a                                                     ; 9703: 20 8a b9     ..
@@ -4191,7 +4205,8 @@ error_template_minus_1 = sub_c96b3+1
 ; &9846 referenced 1 time by &9842
 .c9846
     ldy #&60 ; '`'                                                    ; 9846: a0 60       .`
-    pha                                                               ; 9848: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 9848: 48          H
     tya                                                               ; 9849: 98          .              ; A=&60
     pha                                                               ; 984a: 48          H
     ldx #0                                                            ; 984b: a2 00       ..
@@ -4206,7 +4221,8 @@ error_template_minus_1 = sub_c96b3+1
     asl a                                                             ; 9858: 0a          .
     beq c987e                                                         ; 9859: f0 23       .#
     jsr sub_c9570                                                     ; 985b: 20 70 95     p.
-    pla                                                               ; 985e: 68          h              ; pull A,Y,X from the stack
+    ; pull A,Y,X from the stack
+    pla                                                               ; 985e: 68          h
     tax                                                               ; 985f: aa          .
     pla                                                               ; 9860: 68          h
     tay                                                               ; 9861: a8          .
@@ -4215,7 +4231,8 @@ error_template_minus_1 = sub_c96b3+1
 ; &9865 referenced 1 time by &987c
 .loop_c9865
     sbc #1                                                            ; 9865: e9 01       ..
-    pha                                                               ; 9867: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 9867: 48          H
     tya                                                               ; 9868: 98          .
     pha                                                               ; 9869: 48          H
     txa                                                               ; 986a: 8a          .
@@ -4274,7 +4291,8 @@ error_template_minus_1 = sub_c96b3+1
     dey                                                               ; 98ab: 88          .
     bpl loop_c989e                                                    ; 98ac: 10 f0       ..
     lda l0d6f                                                         ; 98ae: ad 6f 0d    .o.
-    pha                                                               ; 98b1: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 98b1: 48          H
     tya                                                               ; 98b2: 98          .
     pha                                                               ; 98b3: 48          H
     ldx #0                                                            ; 98b4: a2 00       ..
@@ -4310,14 +4328,16 @@ error_template_minus_1 = sub_c96b3+1
 
 ; &98de referenced 1 time by &98c2
 .c98de
-    pla                                                               ; 98de: 68          h              ; pull A,Y,X from the stack
+    ; pull A,Y,X from the stack
+    pla                                                               ; 98de: 68          h
     tax                                                               ; 98df: aa          .
     pla                                                               ; 98e0: 68          h
     tay                                                               ; 98e1: a8          .
     pla                                                               ; 98e2: 68          h
     beq loop_c98c4                                                    ; 98e3: f0 df       ..
     sbc #1                                                            ; 98e5: e9 01       ..
-    pha                                                               ; 98e7: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 98e7: 48          H
     tya                                                               ; 98e8: 98          .
     pha                                                               ; 98e9: 48          H
     txa                                                               ; 98ea: 8a          .
@@ -4892,7 +4912,8 @@ error_template_minus_1 = sub_c96b3+1
 
 ; &9c03 referenced 1 time by &9bfe
 .c9c03
-    pha                                                               ; 9c03: 48          H              ; push A,X,Y onto the stack
+    ; push A,X,Y onto the stack
+    pha                                                               ; 9c03: 48          H
     txa                                                               ; 9c04: 8a          .
     pha                                                               ; 9c05: 48          H
     tya                                                               ; 9c06: 98          .
@@ -4902,7 +4923,8 @@ error_template_minus_1 = sub_c96b3+1
     jsr sub_cb98f                                                     ; 9c0c: 20 8f b9     ..
     lda l1030,x                                                       ; 9c0f: bd 30 10    .0.
     sta l0f05                                                         ; 9c12: 8d 05 0f    ...
-    pla                                                               ; 9c15: 68          h              ; pull A,X from the stack
+    ; pull A,X from the stack
+    pla                                                               ; 9c15: 68          h
     tax                                                               ; 9c16: aa          .
     pla                                                               ; 9c17: 68          h
     lsr a                                                             ; 9c18: 4a          J
@@ -5220,7 +5242,8 @@ error_template_minus_1 = sub_c96b3+1
     ldx #0                                                            ; 9e09: a2 00       ..
 ; &9e0b referenced 1 time by &9e07
 .c9e0b
-    pla                                                               ; 9e0b: 68          h              ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 9e0b: 68          h
     tay                                                               ; 9e0c: a8          .
     pla                                                               ; 9e0d: 68          h
     rts                                                               ; 9e0e: 60          `
@@ -6964,7 +6987,8 @@ la841 = sub_ca840+1
     cli                                                               ; a976: 58          X
     jmp c983f                                                         ; a977: 4c 3f 98    L?.
 
-    php                                                               ; a97a: 08          .              ; push flags,A,X,Y onto the stack
+    ; push flags,A,X,Y onto the stack
+    php                                                               ; a97a: 08          .
     pha                                                               ; a97b: 48          H
     txa                                                               ; a97c: 8a          .
     pha                                                               ; a97d: 48          H
@@ -6978,7 +7002,8 @@ la841 = sub_ca840+1
     jsr sub_ca993                                                     ; a989: 20 93 a9     ..
 ; &a98c referenced 1 time by &a986
 .ca98c
-    pla                                                               ; a98c: 68          h              ; pull flags,A,X,Y from the stack
+    ; pull flags,A,X,Y from the stack
+    pla                                                               ; a98c: 68          h
     tay                                                               ; a98d: a8          .
     pla                                                               ; a98e: 68          h
     tax                                                               ; a98f: aa          .
@@ -9281,7 +9306,8 @@ lb487 = sub_cb485+2
 
 ; &b799 referenced 8 times by &8d87, &8fa0, &94a0, &9bdc, &9c21, &9cc4, &9d8a, &9e58
 .sub_cb799
-    txa                                                               ; b799: 8a          .              ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; b799: 8a          .
     pha                                                               ; b79a: 48          H
     tya                                                               ; b79b: 98          .
     pha                                                               ; b79c: 48          H
@@ -9318,7 +9344,8 @@ lb487 = sub_cb485+2
     sta l00b4,x                                                       ; b7c4: 95 b4       ..
     dex                                                               ; b7c6: ca          .
     bpl loop_cb7c3                                                    ; b7c7: 10 fa       ..
-    pla                                                               ; b7c9: 68          h              ; pull X,Y from the stack
+    ; pull X,Y from the stack
+    pla                                                               ; b7c9: 68          h
     tay                                                               ; b7ca: a8          .
     pla                                                               ; b7cb: 68          h
     tax                                                               ; b7cc: aa          .
@@ -9337,7 +9364,8 @@ lb487 = sub_cb485+2
     equb &b3, &a9,   0, &85, &b2, &68, &aa, &b1, &b2, &ac, &c9, &10   ; b83f: b3 a9 00... ...
     equb &18, &60, &8c, &c9, &10, &48, &a8                            ; b84b: 18 60 8c... .`.
 
-    txa                                                               ; b852: 8a          .              ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; b852: 8a          .
     pha                                                               ; b853: 48          H
     tya                                                               ; b854: 98          .
     pha                                                               ; b855: 48          H
@@ -9400,7 +9428,8 @@ lb487 = sub_cb485+2
     jsr sub_cb78b                                                     ; b8cb: 20 8b b7     ..
     lda #0                                                            ; b8ce: a9 00       ..
     jsr sub_cb98f                                                     ; b8d0: 20 8f b9     ..
-    pla                                                               ; b8d3: 68          h              ; pull A,X from the stack
+    ; pull A,X from the stack
+    pla                                                               ; b8d3: 68          h
     tax                                                               ; b8d4: aa          .
     pla                                                               ; b8d5: 68          h
     ldy l10c9                                                         ; b8d6: ac c9 10    ...
@@ -9408,7 +9437,8 @@ lb487 = sub_cb485+2
 
 ; &b8da referenced 1 time by &b6c3
 .sub_cb8da
-    pha                                                               ; b8da: 48          H              ; push A,X,Y onto the stack
+    ; push A,X,Y onto the stack
+    pha                                                               ; b8da: 48          H
     txa                                                               ; b8db: 8a          .
     pha                                                               ; b8dc: 48          H
     tya                                                               ; b8dd: 98          .
@@ -9417,7 +9447,8 @@ lb487 = sub_cb485+2
     bne cb8f3                                                         ; b8e2: d0 0f       ..
 ; &b8e4 referenced 1 time by &b895
 .sub_cb8e4
-    pha                                                               ; b8e4: 48          H              ; push A,X,Y onto the stack
+    ; push A,X,Y onto the stack
+    pha                                                               ; b8e4: 48          H
     txa                                                               ; b8e5: 8a          .
     pha                                                               ; b8e6: 48          H
     tya                                                               ; b8e7: 98          .
@@ -9433,7 +9464,8 @@ lb487 = sub_cb485+2
     tax                                                               ; b8f6: aa          .
     pla                                                               ; b8f7: 68          h
     tay                                                               ; b8f8: a8          .
-    pha                                                               ; b8f9: 48          H              ; push A,X onto the stack
+    ; push A,X onto the stack
+    pha                                                               ; b8f9: 48          H
     txa                                                               ; b8fa: 8a          .
     pha                                                               ; b8fb: 48          H
     ldx #0                                                            ; b8fc: a2 00       ..
@@ -9452,7 +9484,8 @@ lb487 = sub_cb485+2
     lda l10d7                                                         ; b91c: ad d7 10    ...
     jsr sub_cb92b                                                     ; b91f: 20 2b b9     +.
     jsr sub_cb721                                                     ; b922: 20 21 b7     !.
-    pla                                                               ; b925: 68          h              ; pull A,X,Y from the stack
+    ; pull A,X,Y from the stack
+    pla                                                               ; b925: 68          h
     tay                                                               ; b926: a8          .
     pla                                                               ; b927: 68          h
     tax                                                               ; b928: aa          .
@@ -9463,7 +9496,8 @@ lb487 = sub_cb485+2
 .sub_cb92b
     sty l0fde                                                         ; b92b: 8c de 0f    ...
     sta l0fdf                                                         ; b92e: 8d df 0f    ...
-    tya                                                               ; b931: 98          .              ; push Y,X onto the stack
+    ; push Y,X onto the stack
+    tya                                                               ; b931: 98          .
     pha                                                               ; b932: 48          H
     txa                                                               ; b933: 8a          .
     pha                                                               ; b934: 48          H
@@ -9505,7 +9539,8 @@ lb487 = sub_cb485+2
     lda l1040,x                                                       ; b977: bd 40 10    .@.
     eor #1                                                            ; b97a: 49 01       I.
     sta l1040,x                                                       ; b97c: 9d 40 10    .@.
-    pla                                                               ; b97f: 68          h              ; pull Y,X from the stack
+    ; pull Y,X from the stack
+    pla                                                               ; b97f: 68          h
     tax                                                               ; b980: aa          .
     pla                                                               ; b981: 68          h
     tay                                                               ; b982: a8          .
@@ -9835,7 +9870,8 @@ lb487 = sub_cb485+2
 ; &bb39 referenced 1 time by &bb2d
 .cbb39
     and #&0f                                                          ; bb39: 29 0f       ).
-    pha                                                               ; bb3b: 48          H              ; push A,X onto the stack
+    ; push A,X onto the stack
+    pha                                                               ; bb3b: 48          H
     txa                                                               ; bb3c: 8a          .
     pha                                                               ; bb3d: 48          H
     ldx #4                                                            ; bb3e: a2 04       ..
@@ -9860,7 +9896,8 @@ lb487 = sub_cb485+2
     bcs cbb64                                                         ; bb53: b0 0f       ..
     dex                                                               ; bb55: ca          .
     bne loop_cbb40                                                    ; bb56: d0 e8       ..
-    pla                                                               ; bb58: 68          h              ; pull A,X from the stack
+    ; pull A,X from the stack
+    pla                                                               ; bb58: 68          h
     tax                                                               ; bb59: aa          .
     pla                                                               ; bb5a: 68          h
     ldy #0                                                            ; bb5b: a0 00       ..

--- a/examples/known_good/anfs418_xa.asm
+++ b/examples/known_good/anfs418_xa.asm
@@ -350,7 +350,8 @@ sub_c8028
 
 // $8032 referenced 1 time by $802d
 c8032
-    txa                                                               // 8032: 8a          .              // push X,Y onto the stack
+    // push X,Y onto the stack
+    txa                                                               // 8032: 8a          .
     pha                                                               // 8033: 48          H
     tya                                                               // 8034: 98          .
     pha                                                               // 8035: 48          H
@@ -1154,7 +1155,8 @@ return_4
 
 // $8585 referenced 1 time by $8057
 c8585
-    pla                                                               // 8585: 68          h              // pull X,Y from the stack
+    // pull X,Y from the stack
+    pla                                                               // 8585: 68          h
     tay                                                               // 8586: a8          .
     pla                                                               // 8587: 68          h
     tax                                                               // 8588: aa          .
@@ -1834,7 +1836,8 @@ c89a4
 // $89a6 referenced 1 time by $8096
 sub_c89a7
     bit station_id_disable_net_nmis                                   // 89a7: 2c 18 fe    ,..
-    pha                                                               // 89aa: 48          H              // push A,Y onto the stack
+    // push A,Y onto the stack
+    pha                                                               // 89aa: 48          H
     tya                                                               // 89ab: 98          .
     pha                                                               // 89ac: 48          H
     lda #0                                                            // 89ad: a9 00       ..
@@ -1845,7 +1848,8 @@ sub_c89a7
     sta l0d0c                                                         // 89b8: 8d 0c 0d    ...
     lda romsel_copy                                                   // 89bb: a5 f4       ..
     sta romsel                                                        // 89bd: 8d 30 fe    .0.
-    pla                                                               // 89c0: 68          h              // pull A,Y from the stack
+    // pull A,Y from the stack
+    pla                                                               // 89c0: 68          h
     tay                                                               // 89c1: a8          .
     pla                                                               // 89c2: 68          h
     bit video_ula_control                                             // 89c3: 2c 20 fe    , .
@@ -1968,7 +1972,8 @@ c8a33
 // $8a38 referenced 2 times by $8a25, $8a29
 c8a38
     ldx romsel_copy                                                   // 8a38: a6 f4       ..
-    pla                                                               // 8a3a: 68          h              // pull A,Y from the stack
+    // pull A,Y from the stack
+    pla                                                               // 8a3a: 68          h
     tay                                                               // 8a3b: a8          .
 // $8a3c referenced 1 time by $8a18
 service_handler_common1
@@ -2209,12 +2214,14 @@ sub_c8b96
 // $8b98 referenced 2 times by $8b8f, $8b94
 c8b98
     bvc c8ba8                                                         // 8b98: 50 0e       P.
-    txa                                                               // 8b9a: 8a          .              // push X,Y onto the stack
+    // push X,Y onto the stack
+    txa                                                               // 8b9a: 8a          .
     pha                                                               // 8b9b: 48          H
     tya                                                               // 8b9c: 98          .
     pha                                                               // 8b9d: 48          H
     jsr sub_c8c9f                                                     // 8b9e: 20 9f 8c     ..
-    pla                                                               // 8ba1: 68          h              // pull X,Y from the stack
+    // pull X,Y from the stack
+    pla                                                               // 8ba1: 68          h
     tay                                                               // 8ba2: a8          .
     pla                                                               // 8ba3: 68          h
     tax                                                               // 8ba4: aa          .
@@ -2912,7 +2919,8 @@ return_11
 // $8fcb referenced 5 times by $9bbe, $9d4e, $9dee, $9e2f, $b5fb
 sub_c8fcb
     php                                                               // 8fcb: 08          .
-    pha                                                               // 8fcc: 48          H              // push A,Y onto the stack
+    // push A,Y onto the stack
+    pha                                                               // 8fcc: 48          H
     tya                                                               // 8fcd: 98          .
     pha                                                               // 8fce: 48          H
     ldy #$76 // 'v'                                                   // 8fcf: a0 76       .v
@@ -2926,7 +2934,8 @@ loop_c8fd4
     ldy #$77 // 'w'                                                   // 8fd9: a0 77       .w
     cmp (l00cc),y                                                     // 8fdb: d1 cc       ..
     bne c8fe4                                                         // 8fdd: d0 05       ..
-    pla                                                               // 8fdf: 68          h              // pull A,Y from the stack
+    // pull A,Y from the stack
+    pla                                                               // 8fdf: 68          h
     tay                                                               // 8fe0: a8          .
     pla                                                               // 8fe1: 68          h
     plp                                                               // 8fe2: 28          (
@@ -3281,7 +3290,8 @@ sub_c92b0
 
 // $92b5 referenced 2 times by $9c48, $9e8f
 sub_c92b5
-    php                                                               // 92b5: 08          .              // push flags,A,X onto the stack
+    // push flags,A,X onto the stack
+    php                                                               // 92b5: 08          .
     pha                                                               // 92b6: 48          H
     txa                                                               // 92b7: 8a          .
     pha                                                               // 92b8: 48          H
@@ -3295,7 +3305,8 @@ sub_c92b5
     bne c92e1                                                         // 92ca: d0 15       ..
 // $92cc referenced 2 times by $9ca9, $9e8a
 sub_c92cc
-    php                                                               // 92cc: 08          .              // push flags,A,X onto the stack
+    // push flags,A,X onto the stack
+    php                                                               // 92cc: 08          .
     pha                                                               // 92cd: 48          H
     txa                                                               // 92ce: 8a          .
     pha                                                               // 92cf: 48          H
@@ -3308,7 +3319,8 @@ sub_c92cc
     sta l1060,x                                                       // 92de: 9d 60 10    .`.
 // $92e1 referenced 3 times by $92c0, $92ca, $92d7
 c92e1
-    pla                                                               // 92e1: 68          h              // pull flags,A,X from the stack
+    // pull flags,A,X from the stack
+    pla                                                               // 92e1: 68          h
     tax                                                               // 92e2: aa          .
     pla                                                               // 92e3: 68          h
     plp                                                               // 92e4: 28          (
@@ -3466,7 +3478,8 @@ c93bc
     txa                                                               // 93cd: 8a          .
     pha                                                               // 93ce: 48          H
     jsr sub_cae97                                                     // 93cf: 20 97 ae     ..
-    pla                                                               // 93d2: 68          h              // pull A,X from the stack
+    // pull A,X from the stack
+    pla                                                               // 93d2: 68          h
     tax                                                               // 93d3: aa          .
     pla                                                               // 93d4: 68          h
     cmp l1071                                                         // 93d5: cd 71 10    .q.
@@ -4027,7 +4040,8 @@ c96fa
 // $96fd referenced 1 time by $96f3
 c96fd
     sta l0e08                                                         // 96fd: 8d 08 0e    ...
-    pha                                                               // 9700: 48          H              // push A,X onto the stack
+    // push A,X onto the stack
+    pha                                                               // 9700: 48          H
     txa                                                               // 9701: 8a          .
     pha                                                               // 9702: 48          H
     jsr sub_cb98a                                                     // 9703: 20 8a b9     ..
@@ -4191,7 +4205,8 @@ c983f
 // $9846 referenced 1 time by $9842
 c9846
     ldy #$60 // '`'                                                   // 9846: a0 60       .`
-    pha                                                               // 9848: 48          H              // push A,Y onto the stack
+    // push A,Y onto the stack
+    pha                                                               // 9848: 48          H
     tya                                                               // 9849: 98          .              // A=$60
     pha                                                               // 984a: 48          H
     ldx #0                                                            // 984b: a2 00       ..
@@ -4206,7 +4221,8 @@ c984f
     asl                                                               // 9858: 0a          .
     beq c987e                                                         // 9859: f0 23       .#
     jsr sub_c9570                                                     // 985b: 20 70 95     p.
-    pla                                                               // 985e: 68          h              // pull A,Y,X from the stack
+    // pull A,Y,X from the stack
+    pla                                                               // 985e: 68          h
     tax                                                               // 985f: aa          .
     pla                                                               // 9860: 68          h
     tay                                                               // 9861: a8          .
@@ -4215,7 +4231,8 @@ c984f
 // $9865 referenced 1 time by $987c
 loop_c9865
     sbc #1                                                            // 9865: e9 01       ..
-    pha                                                               // 9867: 48          H              // push A,Y onto the stack
+    // push A,Y onto the stack
+    pha                                                               // 9867: 48          H
     tya                                                               // 9868: 98          .
     pha                                                               // 9869: 48          H
     txa                                                               // 986a: 8a          .
@@ -4274,7 +4291,8 @@ c98ab
     dey                                                               // 98ab: 88          .
     bpl loop_c989e                                                    // 98ac: 10 f0       ..
     lda l0d6f                                                         // 98ae: ad 6f 0d    .o.
-    pha                                                               // 98b1: 48          H              // push A,Y onto the stack
+    // push A,Y onto the stack
+    pha                                                               // 98b1: 48          H
     tya                                                               // 98b2: 98          .
     pha                                                               // 98b3: 48          H
     ldx #0                                                            // 98b4: a2 00       ..
@@ -4310,14 +4328,16 @@ loop_c98d9
 
 // $98de referenced 1 time by $98c2
 c98de
-    pla                                                               // 98de: 68          h              // pull A,Y,X from the stack
+    // pull A,Y,X from the stack
+    pla                                                               // 98de: 68          h
     tax                                                               // 98df: aa          .
     pla                                                               // 98e0: 68          h
     tay                                                               // 98e1: a8          .
     pla                                                               // 98e2: 68          h
     beq loop_c98c4                                                    // 98e3: f0 df       ..
     sbc #1                                                            // 98e5: e9 01       ..
-    pha                                                               // 98e7: 48          H              // push A,Y onto the stack
+    // push A,Y onto the stack
+    pha                                                               // 98e7: 48          H
     tya                                                               // 98e8: 98          .
     pha                                                               // 98e9: 48          H
     txa                                                               // 98ea: 8a          .
@@ -4892,7 +4912,8 @@ c9bf8
 
 // $9c03 referenced 1 time by $9bfe
 c9c03
-    pha                                                               // 9c03: 48          H              // push A,X,Y onto the stack
+    // push A,X,Y onto the stack
+    pha                                                               // 9c03: 48          H
     txa                                                               // 9c04: 8a          .
     pha                                                               // 9c05: 48          H
     tya                                                               // 9c06: 98          .
@@ -4902,7 +4923,8 @@ c9c03
     jsr sub_cb98f                                                     // 9c0c: 20 8f b9     ..
     lda l1030,x                                                       // 9c0f: bd 30 10    .0.
     sta l0f05                                                         // 9c12: 8d 05 0f    ...
-    pla                                                               // 9c15: 68          h              // pull A,X from the stack
+    // pull A,X from the stack
+    pla                                                               // 9c15: 68          h
     tax                                                               // 9c16: aa          .
     pla                                                               // 9c17: 68          h
     lsr                                                               // 9c18: 4a          J
@@ -5220,7 +5242,8 @@ c9e09
     ldx #0                                                            // 9e09: a2 00       ..
 // $9e0b referenced 1 time by $9e07
 c9e0b
-    pla                                                               // 9e0b: 68          h              // pull A,Y from the stack
+    // pull A,Y from the stack
+    pla                                                               // 9e0b: 68          h
     tay                                                               // 9e0c: a8          .
     pla                                                               // 9e0d: 68          h
     rts                                                               // 9e0e: 60          `
@@ -6964,7 +6987,8 @@ sub_ca976
     cli                                                               // a976: 58          X
     jmp c983f                                                         // a977: 4c 3f 98    L?.
 
-    php                                                               // a97a: 08          .              // push flags,A,X,Y onto the stack
+    // push flags,A,X,Y onto the stack
+    php                                                               // a97a: 08          .
     pha                                                               // a97b: 48          H
     txa                                                               // a97c: 8a          .
     pha                                                               // a97d: 48          H
@@ -6978,7 +7002,8 @@ sub_ca976
     jsr sub_ca993                                                     // a989: 20 93 a9     ..
 // $a98c referenced 1 time by $a986
 ca98c
-    pla                                                               // a98c: 68          h              // pull flags,A,X,Y from the stack
+    // pull flags,A,X,Y from the stack
+    pla                                                               // a98c: 68          h
     tay                                                               // a98d: a8          .
     pla                                                               // a98e: 68          h
     tax                                                               // a98f: aa          .
@@ -9281,7 +9306,8 @@ return_38
 
 // $b799 referenced 8 times by $8d87, $8fa0, $94a0, $9bdc, $9c21, $9cc4, $9d8a, $9e58
 sub_cb799
-    txa                                                               // b799: 8a          .              // push X,Y onto the stack
+    // push X,Y onto the stack
+    txa                                                               // b799: 8a          .
     pha                                                               // b79a: 48          H
     tya                                                               // b79b: 98          .
     pha                                                               // b79c: 48          H
@@ -9318,7 +9344,8 @@ loop_cb7c3
     sta l00b4,x                                                       // b7c4: 95 b4       ..
     dex                                                               // b7c6: ca          .
     bpl loop_cb7c3                                                    // b7c7: 10 fa       ..
-    pla                                                               // b7c9: 68          h              // pull X,Y from the stack
+    // pull X,Y from the stack
+    pla                                                               // b7c9: 68          h
     tay                                                               // b7ca: a8          .
     pla                                                               // b7cb: 68          h
     tax                                                               // b7cc: aa          .
@@ -9337,7 +9364,8 @@ loop_cb7c3
     .byt $b3, $a9,   0, $85, $b2, $68, $aa, $b1, $b2, $ac, $c9, $10   // b83f: b3 a9 00... ...
     .byt $18, $60, $8c, $c9, $10, $48, $a8                            // b84b: 18 60 8c... .`.
 
-    txa                                                               // b852: 8a          .              // push X,Y onto the stack
+    // push X,Y onto the stack
+    txa                                                               // b852: 8a          .
     pha                                                               // b853: 48          H
     tya                                                               // b854: 98          .
     pha                                                               // b855: 48          H
@@ -9400,7 +9428,8 @@ cb8cb
     jsr sub_cb78b                                                     // b8cb: 20 8b b7     ..
     lda #0                                                            // b8ce: a9 00       ..
     jsr sub_cb98f                                                     // b8d0: 20 8f b9     ..
-    pla                                                               // b8d3: 68          h              // pull A,X from the stack
+    // pull A,X from the stack
+    pla                                                               // b8d3: 68          h
     tax                                                               // b8d4: aa          .
     pla                                                               // b8d5: 68          h
     ldy l10c9                                                         // b8d6: ac c9 10    ...
@@ -9408,7 +9437,8 @@ cb8cb
 
 // $b8da referenced 1 time by $b6c3
 sub_cb8da
-    pha                                                               // b8da: 48          H              // push A,X,Y onto the stack
+    // push A,X,Y onto the stack
+    pha                                                               // b8da: 48          H
     txa                                                               // b8db: 8a          .
     pha                                                               // b8dc: 48          H
     tya                                                               // b8dd: 98          .
@@ -9417,7 +9447,8 @@ sub_cb8da
     bne cb8f3                                                         // b8e2: d0 0f       ..
 // $b8e4 referenced 1 time by $b895
 sub_cb8e4
-    pha                                                               // b8e4: 48          H              // push A,X,Y onto the stack
+    // push A,X,Y onto the stack
+    pha                                                               // b8e4: 48          H
     txa                                                               // b8e5: 8a          .
     pha                                                               // b8e6: 48          H
     tya                                                               // b8e7: 98          .
@@ -9433,7 +9464,8 @@ cb8f3
     tax                                                               // b8f6: aa          .
     pla                                                               // b8f7: 68          h
     tay                                                               // b8f8: a8          .
-    pha                                                               // b8f9: 48          H              // push A,X onto the stack
+    // push A,X onto the stack
+    pha                                                               // b8f9: 48          H
     txa                                                               // b8fa: 8a          .
     pha                                                               // b8fb: 48          H
     ldx #0                                                            // b8fc: a2 00       ..
@@ -9452,7 +9484,8 @@ cb8f3
     lda l10d7                                                         // b91c: ad d7 10    ...
     jsr sub_cb92b                                                     // b91f: 20 2b b9     +.
     jsr sub_cb721                                                     // b922: 20 21 b7     !.
-    pla                                                               // b925: 68          h              // pull A,X,Y from the stack
+    // pull A,X,Y from the stack
+    pla                                                               // b925: 68          h
     tay                                                               // b926: a8          .
     pla                                                               // b927: 68          h
     tax                                                               // b928: aa          .
@@ -9463,7 +9496,8 @@ cb8f3
 sub_cb92b
     sty l0fde                                                         // b92b: 8c de 0f    ...
     sta l0fdf                                                         // b92e: 8d df 0f    ...
-    tya                                                               // b931: 98          .              // push Y,X onto the stack
+    // push Y,X onto the stack
+    tya                                                               // b931: 98          .
     pha                                                               // b932: 48          H
     txa                                                               // b933: 8a          .
     pha                                                               // b934: 48          H
@@ -9505,7 +9539,8 @@ cb974
     lda l1040,x                                                       // b977: bd 40 10    .@.
     eor #1                                                            // b97a: 49 01       I.
     sta l1040,x                                                       // b97c: 9d 40 10    .@.
-    pla                                                               // b97f: 68          h              // pull Y,X from the stack
+    // pull Y,X from the stack
+    pla                                                               // b97f: 68          h
     tax                                                               // b980: aa          .
     pla                                                               // b981: 68          h
     tay                                                               // b982: a8          .
@@ -9835,7 +9870,8 @@ cbb1a
 // $bb39 referenced 1 time by $bb2d
 cbb39
     and #$0f                                                          // bb39: 29 0f       ).
-    pha                                                               // bb3b: 48          H              // push A,X onto the stack
+    // push A,X onto the stack
+    pha                                                               // bb3b: 48          H
     txa                                                               // bb3c: 8a          .
     pha                                                               // bb3d: 48          H
     ldx #4                                                            // bb3e: a2 04       ..
@@ -9860,7 +9896,8 @@ loop_cbb43
     bcs cbb64                                                         // bb53: b0 0f       ..
     dex                                                               // bb55: ca          .
     bne loop_cbb40                                                    // bb56: d0 e8       ..
-    pla                                                               // bb58: 68          h              // pull A,X from the stack
+    // pull A,X from the stack
+    pla                                                               // bb58: 68          h
     tax                                                               // bb59: aa          .
     pla                                                               // bb5a: 68          h
     ldy #0                                                            // bb5b: a0 00       ..

--- a/examples/known_good/chuckie_acme.asm
+++ b/examples/known_good/chuckie_acme.asm
@@ -1391,7 +1391,8 @@ morebitsleft
     lsr pixelvalue                                                    ; 194b: 46 82       F.
     dec columncounter                                                 ; 194d: c6 81       ..
     bne plotpixelloop                                                 ; 194f: d0 da       ..
-    tya                                                               ; 1951: 98          .              ; add 8 to Y
+    ; add 8 to Y
+    tya                                                               ; 1951: 98          .
     clc                                                               ; 1952: 18          .
     adc #8                                                            ; 1953: 69 08       i.
     tay                                                               ; 1955: a8          .

--- a/examples/known_good/chuckie_beebasm.asm
+++ b/examples/known_good/chuckie_beebasm.asm
@@ -1391,7 +1391,8 @@ osbyte                  = &fff4
     lsr pixelvalue                                                    ; 194b: 46 82       F.
     dec columncounter                                                 ; 194d: c6 81       ..
     bne plotpixelloop                                                 ; 194f: d0 da       ..
-    tya                                                               ; 1951: 98          .              ; add 8 to Y
+    ; add 8 to Y
+    tya                                                               ; 1951: 98          .
     clc                                                               ; 1952: 18          .
     adc #8                                                            ; 1953: 69 08       i.
     tay                                                               ; 1955: a8          .

--- a/examples/known_good/chuckie_xa.asm
+++ b/examples/known_good/chuckie_xa.asm
@@ -1391,7 +1391,8 @@ morebitsleft
     lsr pixelvalue                                                    // 194b: 46 82       F.
     dec columncounter                                                 // 194d: c6 81       ..
     bne plotpixelloop                                                 // 194f: d0 da       ..
-    tya                                                               // 1951: 98          .              // add 8 to Y
+    // add 8 to Y
+    tya                                                               // 1951: 98          .
     clc                                                               // 1952: 18          .
     adc #8                                                            // 1953: 69 08       i.
     tay                                                               // 1955: a8          .

--- a/examples/known_good/dfs226_acme.asm
+++ b/examples/known_good/dfs226_acme.asm
@@ -395,7 +395,8 @@ print_inline_l809f_top_bit_clear
     pla                                                               ; 807c: 68          h
     sta l00af                                                         ; 807d: 85 af       ..
     lda l00b3                                                         ; 807f: a5 b3       ..
-    pha                                                               ; 8081: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 8081: 48          H
     tya                                                               ; 8082: 98          .
     pha                                                               ; 8083: 48          H
     ldy #0                                                            ; 8084: a0 00       ..
@@ -409,7 +410,8 @@ loop_c8086
 
 ; $8093 referenced 1 time by $808b
 c8093
-    pla                                                               ; 8093: 68          h              ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 8093: 68          h
     tay                                                               ; 8094: a8          .
     pla                                                               ; 8095: 68          h
 ; $8096 referenced 1 time by $806d
@@ -433,7 +435,8 @@ c809f
     pha                                                               ; 80a9: 48          H
     ora #$10                                                          ; 80aa: 09 10       ..
     jsr sub_c9ad3                                                     ; 80ac: 20 d3 9a     ..
-    pla                                                               ; 80af: 68          h              ; pull A,X from the stack
+    ; pull A,X from the stack
+    pla                                                               ; 80af: 68          h
     tax                                                               ; 80b0: aa          .
     pla                                                               ; 80b1: 68          h
     jsr osasci                                                        ; 80b2: 20 e3 ff     ..            ; Write character
@@ -1059,7 +1062,8 @@ return_6
 
 ; $83e3 referenced 29 times by $809f, $8174, $82bb, $833a, $8380, $8386, $8951, $8a32, $96c3, $97cd, $993b, $99f3, $9a0f, $9a32, $9a63, $9ac8, $9ad8, $9b51, $9bf2, $9c10, $9d9b, $9f7c, $9f82, $a06c, $a190, $a1b4, $a379, $a384, $ac72
 sub_c83e3
-    pha                                                               ; 83e3: 48          H              ; push A,X,Y onto the stack
+    ; push A,X,Y onto the stack
+    pha                                                               ; 83e3: 48          H
     txa                                                               ; 83e4: 8a          .
     pha                                                               ; 83e5: 48          H
     tya                                                               ; 83e6: 98          .
@@ -1090,7 +1094,8 @@ loop_c83fa
     pla                                                               ; 8405: 68          h
 ; $8406 referenced 1 time by $8418
 loop_c8406
-    pla                                                               ; 8406: 68          h              ; pull A,X,Y from the stack
+    ; pull A,X,Y from the stack
+    pla                                                               ; 8406: 68          h
     tay                                                               ; 8407: a8          .
     pla                                                               ; 8408: 68          h
     tax                                                               ; 8409: aa          .
@@ -1099,7 +1104,8 @@ loop_c8406
 
 ; $840c referenced 5 times by $841b, $9785, $9c16, $9e94, $aadd
 sub_c840c
-    pha                                                               ; 840c: 48          H              ; push A,X,Y onto the stack
+    ; push A,X,Y onto the stack
+    pha                                                               ; 840c: 48          H
     txa                                                               ; 840d: 8a          .
     pha                                                               ; 840e: 48          H
     tya                                                               ; 840f: 98          .
@@ -3765,7 +3771,8 @@ sub_c93c5
     tay                                                               ; 93c5: a8          .
     lda (l00b2),y                                                     ; 93c6: b1 b2       ..
     tax                                                               ; 93c8: aa          .
-    tya                                                               ; 93c9: 98          .              ; add 18 to Y
+    ; add 18 to Y
+    tya                                                               ; 93c9: 98          .
     clc                                                               ; 93ca: 18          .
     adc #$12                                                          ; 93cb: 69 12       i.
     tay                                                               ; 93cd: a8          .
@@ -4210,7 +4217,8 @@ return_28
 c9683
     cmp #service_claim_private_workspace                              ; 9683: c9 02       ..
     bne c96c3                                                         ; 9685: d0 3c       .<
-    pha                                                               ; 9687: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 9687: 48          H
     tya                                                               ; 9688: 98          .
     pha                                                               ; 9689: 48          H
     sta l00b1                                                         ; 968a: 85 b1       ..
@@ -5362,13 +5370,15 @@ c9d89
 
 ; $9d8e referenced 6 times by $956f, $9714, $97d0, $9d72, $9daa, $9db8
 zero_stacked_XXX
-    pha                                                               ; 9d8e: 48          H              ; push A,X onto the stack
+    ; push A,X onto the stack
+    pha                                                               ; 9d8e: 48          H
     txa                                                               ; 9d8f: 8a          .
     pha                                                               ; 9d90: 48          H
     lda #0                                                            ; 9d91: a9 00       ..
     tsx                                                               ; 9d93: ba          .
     sta l0109,x                                                       ; 9d94: 9d 09 01    ...
-    pla                                                               ; 9d97: 68          h              ; pull A,X from the stack
+    ; pull A,X from the stack
+    pla                                                               ; 9d97: 68          h
     tax                                                               ; 9d98: aa          .
     pla                                                               ; 9d99: 68          h
     rts                                                               ; 9d9a: 60          `
@@ -5513,7 +5523,8 @@ sub_c9e54
 return_40
     rts                                                               ; 9e5c: 60          `
 
-    pha                                                               ; 9e5d: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 9e5d: 48          H
     tya                                                               ; 9e5e: 98          .
     pha                                                               ; 9e5f: 48          H
     txa                                                               ; 9e60: 8a          .
@@ -5530,7 +5541,8 @@ c9e6f
     ldx #0                                                            ; 9e6f: a2 00       ..
 ; $9e71 referenced 1 time by $9e6d
 c9e71
-    pla                                                               ; 9e71: 68          h              ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 9e71: 68          h
     tay                                                               ; 9e72: a8          .
     pla                                                               ; 9e73: 68          h
 ; $9e74 referenced 1 time by $9e7b
@@ -7135,7 +7147,8 @@ print_inline_osasci_top_bit_clear
     pla                                                               ; a9a1: 68          h
     sta l00af                                                         ; a9a2: 85 af       ..
     lda l00b3                                                         ; a9a4: a5 b3       ..
-    pha                                                               ; a9a6: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; a9a6: 48          H
     tya                                                               ; a9a7: 98          .
     pha                                                               ; a9a8: 48          H
     ldy #0                                                            ; a9a9: a0 00       ..
@@ -7149,7 +7162,8 @@ loop_ca9ab
 
 ; $a9b8 referenced 1 time by $a9b0
 ca9b8
-    pla                                                               ; a9b8: 68          h              ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; a9b8: 68          h
     tay                                                               ; a9b9: a8          .
     pla                                                               ; a9ba: 68          h
     clc                                                               ; a9bb: 18          .
@@ -8388,7 +8402,8 @@ general_service_handler
     lda l00b8                                                         ; b1b6: a5 b8       ..
     pha                                                               ; b1b8: 48          H
     lda l00b9                                                         ; b1b9: a5 b9       ..
-    pha                                                               ; b1bb: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; b1bb: 48          H
     tya                                                               ; b1bc: 98          .
     pha                                                               ; b1bd: 48          H
     txa                                                               ; b1be: 8a          .
@@ -8440,7 +8455,8 @@ cb1fc
     jsr sub_cb882                                                     ; b200: 20 82 b8     ..
 ; $b203 referenced 10 times by $b1c6, $b1db, $b1df, $b219, $b21e, $b228, $b22c, $b262, $b26a, $b280
 cb203
-    pla                                                               ; b203: 68          h              ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; b203: 68          h
     tay                                                               ; b204: a8          .
     pla                                                               ; b205: 68          h
     sta l00b9                                                         ; b206: 85 b9       ..
@@ -8759,7 +8775,8 @@ cb3ba
 cb3de
     lda #osbyte_read_himem                                            ; b3de: a9 84       ..
     jsr osbyte                                                        ; b3e0: 20 f4 ff     ..            ; Read top of user memory (HIMEM)
-    tya                                                               ; b3e3: 98          .              ; push Y,X onto the stack; X and Y contain the address of HIMEM (low, high)
+    ; push Y,X onto the stack
+    tya                                                               ; b3e3: 98          .              ; X and Y contain the address of HIMEM (low, high)
     pha                                                               ; b3e4: 48          H
     txa                                                               ; b3e5: 8a          .
     pha                                                               ; b3e6: 48          H
@@ -8987,7 +9004,8 @@ cb534
     lda l00bb                                                         ; b548: a5 bb       ..
     iny                                                               ; b54a: c8          .              ; Y=$fc
     adc (l00b8),y                                                     ; b54b: 71 b8       q.
-    pha                                                               ; b54d: 48          H              ; push A,X onto the stack
+    ; push A,X onto the stack
+    pha                                                               ; b54d: 48          H
     txa                                                               ; b54e: 8a          .
     pha                                                               ; b54f: 48          H
     lda #$ff                                                          ; b550: a9 ff       ..
@@ -9360,7 +9378,8 @@ cb736
 ; $b745 referenced 5 times by $b369, $b8b7, $b8d1, $bc78, $bc9e
 sub_cb745
     sta l00bf                                                         ; b745: 85 bf       ..
-    txa                                                               ; b747: 8a          .              ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; b747: 8a          .
     pha                                                               ; b748: 48          H
     tya                                                               ; b749: 98          .
     pha                                                               ; b74a: 48          H
@@ -9383,7 +9402,8 @@ loop_cb75a
     tay                                                               ; b764: a8          .
     lda l00bf                                                         ; b765: a5 bf       ..
     jsr sub_cb771                                                     ; b767: 20 71 b7     q.
-    pla                                                               ; b76a: 68          h              ; pull X,Y from the stack
+    ; pull X,Y from the stack
+    pla                                                               ; b76a: 68          h
     tay                                                               ; b76b: a8          .
     pla                                                               ; b76c: 68          h
     tax                                                               ; b76d: aa          .
@@ -9458,7 +9478,8 @@ loop_cb7be
     lda romsel_copy                                                   ; b7c6: a5 f4       ..
     pha                                                               ; b7c8: 48          H
     lda #1                                                            ; b7c9: a9 01       ..
-    pha                                                               ; b7cb: 48          H              ; push A,X onto the stack
+    ; push A,X onto the stack
+    pha                                                               ; b7cb: 48          H
     txa                                                               ; b7cc: 8a          .
     pha                                                               ; b7cd: 48          H
     lda l00b0                                                         ; b7ce: a5 b0       ..
@@ -9527,7 +9548,8 @@ cb7ed
 
 ; $b82b referenced 16 times by $b1c1, $b2c8, $b2e7, $b32c, $b35a, $b3b0, $b3ec, $b429, $b4a3, $b573, $b5ca, $b5e8, $b604, $b611, $b86b, $beb5
 cb82b
-    php                                                               ; b82b: 08          .              ; push flags,A,X onto the stack
+    ; push flags,A,X onto the stack
+    php                                                               ; b82b: 08          .
     pha                                                               ; b82c: 48          H
     txa                                                               ; b82d: 8a          .
     pha                                                               ; b82e: 48          H
@@ -9536,7 +9558,8 @@ cb82b
     ldx romsel_copy                                                   ; b833: a6 f4       ..
     lda l0df0,x                                                       ; b835: bd f0 0d    ...
     sta l00b9                                                         ; b838: 85 b9       ..
-    pla                                                               ; b83a: 68          h              ; pull flags,A,X from the stack
+    ; pull flags,A,X from the stack
+    pla                                                               ; b83a: 68          h
     tax                                                               ; b83b: aa          .
     pla                                                               ; b83c: 68          h
     plp                                                               ; b83d: 28          (
@@ -9574,13 +9597,15 @@ sub_cb850
 
 ; $b85d referenced 8 times by $b2f2, $b340, $b406, $b63f, $b66e, $b7a7, $be64, $be9d
 sub_cb85d
-    pha                                                               ; b85d: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; b85d: 48          H
     tya                                                               ; b85e: 98          .
     pha                                                               ; b85f: 48          H
     ldy #$ee                                                          ; b860: a0 ee       ..
     lda (l00b8),y                                                     ; b862: b1 b8       ..
     sta l00b8                                                         ; b864: 85 b8       ..
-    pla                                                               ; b866: 68          h              ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; b866: 68          h
     tay                                                               ; b867: a8          .
     pla                                                               ; b868: 68          h
     bit l00b8                                                         ; b869: 24 b8       $.
@@ -9714,7 +9739,8 @@ lb980
 
 ; $b986 referenced 3 times by $b8d4, $bc49, $bcb2
 sub_cb986
-    txa                                                               ; b986: 8a          .              ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; b986: 8a          .
     pha                                                               ; b987: 48          H
     tya                                                               ; b988: 98          .
     pha                                                               ; b989: 48          H
@@ -9768,7 +9794,8 @@ loop_cb9d1
     clc                                                               ; b9d1: 18          .
 ; $b9d2 referenced 1 time by $b9f3
 cb9d2
-    pla                                                               ; b9d2: 68          h              ; pull X,Y from the stack
+    ; pull X,Y from the stack
+    pla                                                               ; b9d2: 68          h
     tay                                                               ; b9d3: a8          .
     pla                                                               ; b9d4: 68          h
     tax                                                               ; b9d5: aa          .
@@ -10656,7 +10683,8 @@ loop_cbeab
     jsr cb82b                                                         ; beb5: 20 2b b8     +.
     stx l00ba                                                         ; beb8: 86 ba       ..
     sty l00bb                                                         ; beba: 84 bb       ..
-    pla                                                               ; bebc: 68          h              ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; bebc: 68          h
     tay                                                               ; bebd: a8          .
     pla                                                               ; bebe: 68          h
     sta (l00ba),y                                                     ; bebf: 91 ba       ..
@@ -10674,7 +10702,8 @@ sub_cbec2
 service_handler
     cmp #service_claim_absolute_workspace                             ; bec8: c9 01       ..
     bne cbee0                                                         ; beca: d0 14       ..
-    pha                                                               ; becc: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; becc: 48          H
     tya                                                               ; becd: 98          .
     pha                                                               ; bece: 48          H
     lda #osbyte_issue_service_request                                 ; becf: a9 8f       ..

--- a/examples/known_good/dfs226_beebasm.asm
+++ b/examples/known_good/dfs226_beebasm.asm
@@ -395,7 +395,8 @@ l8004 = service_entry+1
     pla                                                               ; 807c: 68          h
     sta l00af                                                         ; 807d: 85 af       ..
     lda l00b3                                                         ; 807f: a5 b3       ..
-    pha                                                               ; 8081: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 8081: 48          H
     tya                                                               ; 8082: 98          .
     pha                                                               ; 8083: 48          H
     ldy #0                                                            ; 8084: a0 00       ..
@@ -409,7 +410,8 @@ l8004 = service_entry+1
 
 ; &8093 referenced 1 time by &808b
 .c8093
-    pla                                                               ; 8093: 68          h              ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 8093: 68          h
     tay                                                               ; 8094: a8          .
     pla                                                               ; 8095: 68          h
 ; &8096 referenced 1 time by &806d
@@ -433,7 +435,8 @@ l8004 = service_entry+1
     pha                                                               ; 80a9: 48          H
     ora #&10                                                          ; 80aa: 09 10       ..
     jsr sub_c9ad3                                                     ; 80ac: 20 d3 9a     ..
-    pla                                                               ; 80af: 68          h              ; pull A,X from the stack
+    ; pull A,X from the stack
+    pla                                                               ; 80af: 68          h
     tax                                                               ; 80b0: aa          .
     pla                                                               ; 80b1: 68          h
     jsr osasci                                                        ; 80b2: 20 e3 ff     ..            ; Write character
@@ -1059,7 +1062,8 @@ l8004 = service_entry+1
 
 ; &83e3 referenced 29 times by &809f, &8174, &82bb, &833a, &8380, &8386, &8951, &8a32, &96c3, &97cd, &993b, &99f3, &9a0f, &9a32, &9a63, &9ac8, &9ad8, &9b51, &9bf2, &9c10, &9d9b, &9f7c, &9f82, &a06c, &a190, &a1b4, &a379, &a384, &ac72
 .sub_c83e3
-    pha                                                               ; 83e3: 48          H              ; push A,X,Y onto the stack
+    ; push A,X,Y onto the stack
+    pha                                                               ; 83e3: 48          H
     txa                                                               ; 83e4: 8a          .
     pha                                                               ; 83e5: 48          H
     tya                                                               ; 83e6: 98          .
@@ -1090,7 +1094,8 @@ l8004 = service_entry+1
     pla                                                               ; 8405: 68          h
 ; &8406 referenced 1 time by &8418
 .loop_c8406
-    pla                                                               ; 8406: 68          h              ; pull A,X,Y from the stack
+    ; pull A,X,Y from the stack
+    pla                                                               ; 8406: 68          h
     tay                                                               ; 8407: a8          .
     pla                                                               ; 8408: 68          h
     tax                                                               ; 8409: aa          .
@@ -1099,7 +1104,8 @@ l8004 = service_entry+1
 
 ; &840c referenced 5 times by &841b, &9785, &9c16, &9e94, &aadd
 .sub_c840c
-    pha                                                               ; 840c: 48          H              ; push A,X,Y onto the stack
+    ; push A,X,Y onto the stack
+    pha                                                               ; 840c: 48          H
     txa                                                               ; 840d: 8a          .
     pha                                                               ; 840e: 48          H
     tya                                                               ; 840f: 98          .
@@ -3798,7 +3804,8 @@ nmi_XXX5 = l0d1f+1
     tay                                                               ; 93c5: a8          .
     lda (l00b2),y                                                     ; 93c6: b1 b2       ..
     tax                                                               ; 93c8: aa          .
-    tya                                                               ; 93c9: 98          .              ; add 18 to Y
+    ; add 18 to Y
+    tya                                                               ; 93c9: 98          .
     clc                                                               ; 93ca: 18          .
     adc #&12                                                          ; 93cb: 69 12       i.
     tay                                                               ; 93cd: a8          .
@@ -4243,7 +4250,8 @@ nmi_XXX5 = l0d1f+1
 .c9683
     cmp #service_claim_private_workspace                              ; 9683: c9 02       ..
     bne c96c3                                                         ; 9685: d0 3c       .<
-    pha                                                               ; 9687: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 9687: 48          H
     tya                                                               ; 9688: 98          .
     pha                                                               ; 9689: 48          H
     sta l00b1                                                         ; 968a: 85 b1       ..
@@ -5395,13 +5403,15 @@ nmi_XXX5 = l0d1f+1
 
 ; &9d8e referenced 6 times by &956f, &9714, &97d0, &9d72, &9daa, &9db8
 .zero_stacked_XXX
-    pha                                                               ; 9d8e: 48          H              ; push A,X onto the stack
+    ; push A,X onto the stack
+    pha                                                               ; 9d8e: 48          H
     txa                                                               ; 9d8f: 8a          .
     pha                                                               ; 9d90: 48          H
     lda #0                                                            ; 9d91: a9 00       ..
     tsx                                                               ; 9d93: ba          .
     sta l0109,x                                                       ; 9d94: 9d 09 01    ...
-    pla                                                               ; 9d97: 68          h              ; pull A,X from the stack
+    ; pull A,X from the stack
+    pla                                                               ; 9d97: 68          h
     tax                                                               ; 9d98: aa          .
     pla                                                               ; 9d99: 68          h
     rts                                                               ; 9d9a: 60          `
@@ -5546,7 +5556,8 @@ nmi_XXX5 = l0d1f+1
 .return_40
     rts                                                               ; 9e5c: 60          `
 
-    pha                                                               ; 9e5d: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 9e5d: 48          H
     tya                                                               ; 9e5e: 98          .
     pha                                                               ; 9e5f: 48          H
     txa                                                               ; 9e60: 8a          .
@@ -5563,7 +5574,8 @@ nmi_XXX5 = l0d1f+1
     ldx #0                                                            ; 9e6f: a2 00       ..
 ; &9e71 referenced 1 time by &9e6d
 .c9e71
-    pla                                                               ; 9e71: 68          h              ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 9e71: 68          h
     tay                                                               ; 9e72: a8          .
     pla                                                               ; 9e73: 68          h
 ; &9e74 referenced 1 time by &9e7b
@@ -7168,7 +7180,8 @@ nmi_XXX5 = l0d1f+1
     pla                                                               ; a9a1: 68          h
     sta l00af                                                         ; a9a2: 85 af       ..
     lda l00b3                                                         ; a9a4: a5 b3       ..
-    pha                                                               ; a9a6: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; a9a6: 48          H
     tya                                                               ; a9a7: 98          .
     pha                                                               ; a9a8: 48          H
     ldy #0                                                            ; a9a9: a0 00       ..
@@ -7182,7 +7195,8 @@ nmi_XXX5 = l0d1f+1
 
 ; &a9b8 referenced 1 time by &a9b0
 .ca9b8
-    pla                                                               ; a9b8: 68          h              ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; a9b8: 68          h
     tay                                                               ; a9b9: a8          .
     pla                                                               ; a9ba: 68          h
     clc                                                               ; a9bb: 18          .
@@ -8454,7 +8468,8 @@ jump_address_low = sub_c0050+1
     lda l00b8                                                         ; b1b6: a5 b8       ..
     pha                                                               ; b1b8: 48          H
     lda l00b9                                                         ; b1b9: a5 b9       ..
-    pha                                                               ; b1bb: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; b1bb: 48          H
     tya                                                               ; b1bc: 98          .
     pha                                                               ; b1bd: 48          H
     txa                                                               ; b1be: 8a          .
@@ -8506,7 +8521,8 @@ jump_address_low = sub_c0050+1
     jsr sub_cb882                                                     ; b200: 20 82 b8     ..
 ; &b203 referenced 10 times by &b1c6, &b1db, &b1df, &b219, &b21e, &b228, &b22c, &b262, &b26a, &b280
 .cb203
-    pla                                                               ; b203: 68          h              ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; b203: 68          h
     tay                                                               ; b204: a8          .
     pla                                                               ; b205: 68          h
     sta l00b9                                                         ; b206: 85 b9       ..
@@ -8825,7 +8841,8 @@ jump_address_low = sub_c0050+1
 .cb3de
     lda #osbyte_read_himem                                            ; b3de: a9 84       ..
     jsr osbyte                                                        ; b3e0: 20 f4 ff     ..            ; Read top of user memory (HIMEM)
-    tya                                                               ; b3e3: 98          .              ; push Y,X onto the stack; X and Y contain the address of HIMEM (low, high)
+    ; push Y,X onto the stack
+    tya                                                               ; b3e3: 98          .              ; X and Y contain the address of HIMEM (low, high)
     pha                                                               ; b3e4: 48          H
     txa                                                               ; b3e5: 8a          .
     pha                                                               ; b3e6: 48          H
@@ -9053,7 +9070,8 @@ jump_address_low = sub_c0050+1
     lda l00bb                                                         ; b548: a5 bb       ..
     iny                                                               ; b54a: c8          .              ; Y=&fc
     adc (l00b8),y                                                     ; b54b: 71 b8       q.
-    pha                                                               ; b54d: 48          H              ; push A,X onto the stack
+    ; push A,X onto the stack
+    pha                                                               ; b54d: 48          H
     txa                                                               ; b54e: 8a          .
     pha                                                               ; b54f: 48          H
     lda #&ff                                                          ; b550: a9 ff       ..
@@ -9426,7 +9444,8 @@ lb6ce = sub_cb6cd+1
 ; &b745 referenced 5 times by &b369, &b8b7, &b8d1, &bc78, &bc9e
 .sub_cb745
     sta l00bf                                                         ; b745: 85 bf       ..
-    txa                                                               ; b747: 8a          .              ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; b747: 8a          .
     pha                                                               ; b748: 48          H
     tya                                                               ; b749: 98          .
     pha                                                               ; b74a: 48          H
@@ -9449,7 +9468,8 @@ lb6ce = sub_cb6cd+1
     tay                                                               ; b764: a8          .
     lda l00bf                                                         ; b765: a5 bf       ..
     jsr sub_cb771                                                     ; b767: 20 71 b7     q.
-    pla                                                               ; b76a: 68          h              ; pull X,Y from the stack
+    ; pull X,Y from the stack
+    pla                                                               ; b76a: 68          h
     tay                                                               ; b76b: a8          .
     pla                                                               ; b76c: 68          h
     tax                                                               ; b76d: aa          .
@@ -9524,7 +9544,8 @@ lb6ce = sub_cb6cd+1
     lda romsel_copy                                                   ; b7c6: a5 f4       ..
     pha                                                               ; b7c8: 48          H
     lda #1                                                            ; b7c9: a9 01       ..
-    pha                                                               ; b7cb: 48          H              ; push A,X onto the stack
+    ; push A,X onto the stack
+    pha                                                               ; b7cb: 48          H
     txa                                                               ; b7cc: 8a          .
     pha                                                               ; b7cd: 48          H
     lda l00b0                                                         ; b7ce: a5 b0       ..
@@ -9593,7 +9614,8 @@ lb6ce = sub_cb6cd+1
 
 ; &b82b referenced 16 times by &b1c1, &b2c8, &b2e7, &b32c, &b35a, &b3b0, &b3ec, &b429, &b4a3, &b573, &b5ca, &b5e8, &b604, &b611, &b86b, &beb5
 .cb82b
-    php                                                               ; b82b: 08          .              ; push flags,A,X onto the stack
+    ; push flags,A,X onto the stack
+    php                                                               ; b82b: 08          .
     pha                                                               ; b82c: 48          H
     txa                                                               ; b82d: 8a          .
     pha                                                               ; b82e: 48          H
@@ -9602,7 +9624,8 @@ lb6ce = sub_cb6cd+1
     ldx romsel_copy                                                   ; b833: a6 f4       ..
     lda l0df0,x                                                       ; b835: bd f0 0d    ...
     sta l00b9                                                         ; b838: 85 b9       ..
-    pla                                                               ; b83a: 68          h              ; pull flags,A,X from the stack
+    ; pull flags,A,X from the stack
+    pla                                                               ; b83a: 68          h
     tax                                                               ; b83b: aa          .
     pla                                                               ; b83c: 68          h
     plp                                                               ; b83d: 28          (
@@ -9640,13 +9663,15 @@ lb6ce = sub_cb6cd+1
 
 ; &b85d referenced 8 times by &b2f2, &b340, &b406, &b63f, &b66e, &b7a7, &be64, &be9d
 .sub_cb85d
-    pha                                                               ; b85d: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; b85d: 48          H
     tya                                                               ; b85e: 98          .
     pha                                                               ; b85f: 48          H
     ldy #&ee                                                          ; b860: a0 ee       ..
     lda (l00b8),y                                                     ; b862: b1 b8       ..
     sta l00b8                                                         ; b864: 85 b8       ..
-    pla                                                               ; b866: 68          h              ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; b866: 68          h
     tay                                                               ; b867: a8          .
     pla                                                               ; b868: 68          h
     bit l00b8                                                         ; b869: 24 b8       $.
@@ -9780,7 +9805,8 @@ lb6ce = sub_cb6cd+1
 
 ; &b986 referenced 3 times by &b8d4, &bc49, &bcb2
 .sub_cb986
-    txa                                                               ; b986: 8a          .              ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; b986: 8a          .
     pha                                                               ; b987: 48          H
     tya                                                               ; b988: 98          .
     pha                                                               ; b989: 48          H
@@ -9834,7 +9860,8 @@ lb6ce = sub_cb6cd+1
     clc                                                               ; b9d1: 18          .
 ; &b9d2 referenced 1 time by &b9f3
 .cb9d2
-    pla                                                               ; b9d2: 68          h              ; pull X,Y from the stack
+    ; pull X,Y from the stack
+    pla                                                               ; b9d2: 68          h
     tay                                                               ; b9d3: a8          .
     pla                                                               ; b9d4: 68          h
     tax                                                               ; b9d5: aa          .
@@ -10722,7 +10749,8 @@ lb6ce = sub_cb6cd+1
     jsr cb82b                                                         ; beb5: 20 2b b8     +.
     stx l00ba                                                         ; beb8: 86 ba       ..
     sty l00bb                                                         ; beba: 84 bb       ..
-    pla                                                               ; bebc: 68          h              ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; bebc: 68          h
     tay                                                               ; bebd: a8          .
     pla                                                               ; bebe: 68          h
     sta (l00ba),y                                                     ; bebf: 91 ba       ..
@@ -10740,7 +10768,8 @@ lb6ce = sub_cb6cd+1
 .service_handler
     cmp #service_claim_absolute_workspace                             ; bec8: c9 01       ..
     bne cbee0                                                         ; beca: d0 14       ..
-    pha                                                               ; becc: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; becc: 48          H
     tya                                                               ; becd: 98          .
     pha                                                               ; bece: 48          H
     lda #osbyte_issue_service_request                                 ; becf: a9 8f       ..

--- a/examples/known_good/dfs226_xa.asm
+++ b/examples/known_good/dfs226_xa.asm
@@ -395,7 +395,8 @@ print_inline_l809f_top_bit_clear
     pla                                                               // 807c: 68          h
     sta l00af                                                         // 807d: 85 af       ..
     lda l00b3                                                         // 807f: a5 b3       ..
-    pha                                                               // 8081: 48          H              // push A,Y onto the stack
+    // push A,Y onto the stack
+    pha                                                               // 8081: 48          H
     tya                                                               // 8082: 98          .
     pha                                                               // 8083: 48          H
     ldy #0                                                            // 8084: a0 00       ..
@@ -409,7 +410,8 @@ loop_c8086
 
 // $8093 referenced 1 time by $808b
 c8093
-    pla                                                               // 8093: 68          h              // pull A,Y from the stack
+    // pull A,Y from the stack
+    pla                                                               // 8093: 68          h
     tay                                                               // 8094: a8          .
     pla                                                               // 8095: 68          h
 // $8096 referenced 1 time by $806d
@@ -433,7 +435,8 @@ c809f
     pha                                                               // 80a9: 48          H
     ora #$10                                                          // 80aa: 09 10       ..
     jsr sub_c9ad3                                                     // 80ac: 20 d3 9a     ..
-    pla                                                               // 80af: 68          h              // pull A,X from the stack
+    // pull A,X from the stack
+    pla                                                               // 80af: 68          h
     tax                                                               // 80b0: aa          .
     pla                                                               // 80b1: 68          h
     jsr osasci                                                        // 80b2: 20 e3 ff     ..            // Write character
@@ -1059,7 +1062,8 @@ return_6
 
 // $83e3 referenced 29 times by $809f, $8174, $82bb, $833a, $8380, $8386, $8951, $8a32, $96c3, $97cd, $993b, $99f3, $9a0f, $9a32, $9a63, $9ac8, $9ad8, $9b51, $9bf2, $9c10, $9d9b, $9f7c, $9f82, $a06c, $a190, $a1b4, $a379, $a384, $ac72
 sub_c83e3
-    pha                                                               // 83e3: 48          H              // push A,X,Y onto the stack
+    // push A,X,Y onto the stack
+    pha                                                               // 83e3: 48          H
     txa                                                               // 83e4: 8a          .
     pha                                                               // 83e5: 48          H
     tya                                                               // 83e6: 98          .
@@ -1090,7 +1094,8 @@ loop_c83fa
     pla                                                               // 8405: 68          h
 // $8406 referenced 1 time by $8418
 loop_c8406
-    pla                                                               // 8406: 68          h              // pull A,X,Y from the stack
+    // pull A,X,Y from the stack
+    pla                                                               // 8406: 68          h
     tay                                                               // 8407: a8          .
     pla                                                               // 8408: 68          h
     tax                                                               // 8409: aa          .
@@ -1099,7 +1104,8 @@ loop_c8406
 
 // $840c referenced 5 times by $841b, $9785, $9c16, $9e94, $aadd
 sub_c840c
-    pha                                                               // 840c: 48          H              // push A,X,Y onto the stack
+    // push A,X,Y onto the stack
+    pha                                                               // 840c: 48          H
     txa                                                               // 840d: 8a          .
     pha                                                               // 840e: 48          H
     tya                                                               // 840f: 98          .
@@ -3762,7 +3768,8 @@ sub_c93c5
     tay                                                               // 93c5: a8          .
     lda (l00b2),y                                                     // 93c6: b1 b2       ..
     tax                                                               // 93c8: aa          .
-    tya                                                               // 93c9: 98          .              // add 18 to Y
+    // add 18 to Y
+    tya                                                               // 93c9: 98          .
     clc                                                               // 93ca: 18          .
     adc #$12                                                          // 93cb: 69 12       i.
     tay                                                               // 93cd: a8          .
@@ -4207,7 +4214,8 @@ return_28
 c9683
     cmp #service_claim_private_workspace                              // 9683: c9 02       ..
     bne c96c3                                                         // 9685: d0 3c       .<
-    pha                                                               // 9687: 48          H              // push A,Y onto the stack
+    // push A,Y onto the stack
+    pha                                                               // 9687: 48          H
     tya                                                               // 9688: 98          .
     pha                                                               // 9689: 48          H
     sta l00b1                                                         // 968a: 85 b1       ..
@@ -5359,13 +5367,15 @@ c9d89
 
 // $9d8e referenced 6 times by $956f, $9714, $97d0, $9d72, $9daa, $9db8
 zero_stacked_XXX
-    pha                                                               // 9d8e: 48          H              // push A,X onto the stack
+    // push A,X onto the stack
+    pha                                                               // 9d8e: 48          H
     txa                                                               // 9d8f: 8a          .
     pha                                                               // 9d90: 48          H
     lda #0                                                            // 9d91: a9 00       ..
     tsx                                                               // 9d93: ba          .
     sta l0109,x                                                       // 9d94: 9d 09 01    ...
-    pla                                                               // 9d97: 68          h              // pull A,X from the stack
+    // pull A,X from the stack
+    pla                                                               // 9d97: 68          h
     tax                                                               // 9d98: aa          .
     pla                                                               // 9d99: 68          h
     rts                                                               // 9d9a: 60          `
@@ -5510,7 +5520,8 @@ sub_c9e54
 return_40
     rts                                                               // 9e5c: 60          `
 
-    pha                                                               // 9e5d: 48          H              // push A,Y onto the stack
+    // push A,Y onto the stack
+    pha                                                               // 9e5d: 48          H
     tya                                                               // 9e5e: 98          .
     pha                                                               // 9e5f: 48          H
     txa                                                               // 9e60: 8a          .
@@ -5527,7 +5538,8 @@ c9e6f
     ldx #0                                                            // 9e6f: a2 00       ..
 // $9e71 referenced 1 time by $9e6d
 c9e71
-    pla                                                               // 9e71: 68          h              // pull A,Y from the stack
+    // pull A,Y from the stack
+    pla                                                               // 9e71: 68          h
     tay                                                               // 9e72: a8          .
     pla                                                               // 9e73: 68          h
 // $9e74 referenced 1 time by $9e7b
@@ -7132,7 +7144,8 @@ print_inline_osasci_top_bit_clear
     pla                                                               // a9a1: 68          h
     sta l00af                                                         // a9a2: 85 af       ..
     lda l00b3                                                         // a9a4: a5 b3       ..
-    pha                                                               // a9a6: 48          H              // push A,Y onto the stack
+    // push A,Y onto the stack
+    pha                                                               // a9a6: 48          H
     tya                                                               // a9a7: 98          .
     pha                                                               // a9a8: 48          H
     ldy #0                                                            // a9a9: a0 00       ..
@@ -7146,7 +7159,8 @@ loop_ca9ab
 
 // $a9b8 referenced 1 time by $a9b0
 ca9b8
-    pla                                                               // a9b8: 68          h              // pull A,Y from the stack
+    // pull A,Y from the stack
+    pla                                                               // a9b8: 68          h
     tay                                                               // a9b9: a8          .
     pla                                                               // a9ba: 68          h
     clc                                                               // a9bb: 18          .
@@ -8382,7 +8396,8 @@ general_service_handler
     lda l00b8                                                         // b1b6: a5 b8       ..
     pha                                                               // b1b8: 48          H
     lda l00b9                                                         // b1b9: a5 b9       ..
-    pha                                                               // b1bb: 48          H              // push A,Y onto the stack
+    // push A,Y onto the stack
+    pha                                                               // b1bb: 48          H
     tya                                                               // b1bc: 98          .
     pha                                                               // b1bd: 48          H
     txa                                                               // b1be: 8a          .
@@ -8434,7 +8449,8 @@ cb1fc
     jsr sub_cb882                                                     // b200: 20 82 b8     ..
 // $b203 referenced 10 times by $b1c6, $b1db, $b1df, $b219, $b21e, $b228, $b22c, $b262, $b26a, $b280
 cb203
-    pla                                                               // b203: 68          h              // pull A,Y from the stack
+    // pull A,Y from the stack
+    pla                                                               // b203: 68          h
     tay                                                               // b204: a8          .
     pla                                                               // b205: 68          h
     sta l00b9                                                         // b206: 85 b9       ..
@@ -8753,7 +8769,8 @@ cb3ba
 cb3de
     lda #osbyte_read_himem                                            // b3de: a9 84       ..
     jsr osbyte                                                        // b3e0: 20 f4 ff     ..            // Read top of user memory (HIMEM)
-    tya                                                               // b3e3: 98          .              // push Y,X onto the stack// X and Y contain the address of HIMEM (low, high)
+    // push Y,X onto the stack
+    tya                                                               // b3e3: 98          .              // X and Y contain the address of HIMEM (low, high)
     pha                                                               // b3e4: 48          H
     txa                                                               // b3e5: 8a          .
     pha                                                               // b3e6: 48          H
@@ -8981,7 +8998,8 @@ cb534
     lda l00bb                                                         // b548: a5 bb       ..
     iny                                                               // b54a: c8          .              // Y=$fc
     adc (l00b8),y                                                     // b54b: 71 b8       q.
-    pha                                                               // b54d: 48          H              // push A,X onto the stack
+    // push A,X onto the stack
+    pha                                                               // b54d: 48          H
     txa                                                               // b54e: 8a          .
     pha                                                               // b54f: 48          H
     lda #$ff                                                          // b550: a9 ff       ..
@@ -9354,7 +9372,8 @@ cb736
 // $b745 referenced 5 times by $b369, $b8b7, $b8d1, $bc78, $bc9e
 sub_cb745
     sta l00bf                                                         // b745: 85 bf       ..
-    txa                                                               // b747: 8a          .              // push X,Y onto the stack
+    // push X,Y onto the stack
+    txa                                                               // b747: 8a          .
     pha                                                               // b748: 48          H
     tya                                                               // b749: 98          .
     pha                                                               // b74a: 48          H
@@ -9377,7 +9396,8 @@ loop_cb75a
     tay                                                               // b764: a8          .
     lda l00bf                                                         // b765: a5 bf       ..
     jsr sub_cb771                                                     // b767: 20 71 b7     q.
-    pla                                                               // b76a: 68          h              // pull X,Y from the stack
+    // pull X,Y from the stack
+    pla                                                               // b76a: 68          h
     tay                                                               // b76b: a8          .
     pla                                                               // b76c: 68          h
     tax                                                               // b76d: aa          .
@@ -9452,7 +9472,8 @@ loop_cb7be
     lda romsel_copy                                                   // b7c6: a5 f4       ..
     pha                                                               // b7c8: 48          H
     lda #1                                                            // b7c9: a9 01       ..
-    pha                                                               // b7cb: 48          H              // push A,X onto the stack
+    // push A,X onto the stack
+    pha                                                               // b7cb: 48          H
     txa                                                               // b7cc: 8a          .
     pha                                                               // b7cd: 48          H
     lda l00b0                                                         // b7ce: a5 b0       ..
@@ -9521,7 +9542,8 @@ cb7ed
 
 // $b82b referenced 16 times by $b1c1, $b2c8, $b2e7, $b32c, $b35a, $b3b0, $b3ec, $b429, $b4a3, $b573, $b5ca, $b5e8, $b604, $b611, $b86b, $beb5
 cb82b
-    php                                                               // b82b: 08          .              // push flags,A,X onto the stack
+    // push flags,A,X onto the stack
+    php                                                               // b82b: 08          .
     pha                                                               // b82c: 48          H
     txa                                                               // b82d: 8a          .
     pha                                                               // b82e: 48          H
@@ -9530,7 +9552,8 @@ cb82b
     ldx romsel_copy                                                   // b833: a6 f4       ..
     lda l0df0,x                                                       // b835: bd f0 0d    ...
     sta l00b9                                                         // b838: 85 b9       ..
-    pla                                                               // b83a: 68          h              // pull flags,A,X from the stack
+    // pull flags,A,X from the stack
+    pla                                                               // b83a: 68          h
     tax                                                               // b83b: aa          .
     pla                                                               // b83c: 68          h
     plp                                                               // b83d: 28          (
@@ -9568,13 +9591,15 @@ sub_cb850
 
 // $b85d referenced 8 times by $b2f2, $b340, $b406, $b63f, $b66e, $b7a7, $be64, $be9d
 sub_cb85d
-    pha                                                               // b85d: 48          H              // push A,Y onto the stack
+    // push A,Y onto the stack
+    pha                                                               // b85d: 48          H
     tya                                                               // b85e: 98          .
     pha                                                               // b85f: 48          H
     ldy #$ee                                                          // b860: a0 ee       ..
     lda (l00b8),y                                                     // b862: b1 b8       ..
     sta l00b8                                                         // b864: 85 b8       ..
-    pla                                                               // b866: 68          h              // pull A,Y from the stack
+    // pull A,Y from the stack
+    pla                                                               // b866: 68          h
     tay                                                               // b867: a8          .
     pla                                                               // b868: 68          h
     bit l00b8                                                         // b869: 24 b8       $.
@@ -9708,7 +9733,8 @@ lb980
 
 // $b986 referenced 3 times by $b8d4, $bc49, $bcb2
 sub_cb986
-    txa                                                               // b986: 8a          .              // push X,Y onto the stack
+    // push X,Y onto the stack
+    txa                                                               // b986: 8a          .
     pha                                                               // b987: 48          H
     tya                                                               // b988: 98          .
     pha                                                               // b989: 48          H
@@ -9762,7 +9788,8 @@ loop_cb9d1
     clc                                                               // b9d1: 18          .
 // $b9d2 referenced 1 time by $b9f3
 cb9d2
-    pla                                                               // b9d2: 68          h              // pull X,Y from the stack
+    // pull X,Y from the stack
+    pla                                                               // b9d2: 68          h
     tay                                                               // b9d3: a8          .
     pla                                                               // b9d4: 68          h
     tax                                                               // b9d5: aa          .
@@ -10650,7 +10677,8 @@ loop_cbeab
     jsr cb82b                                                         // beb5: 20 2b b8     +.
     stx l00ba                                                         // beb8: 86 ba       ..
     sty l00bb                                                         // beba: 84 bb       ..
-    pla                                                               // bebc: 68          h              // pull A,Y from the stack
+    // pull A,Y from the stack
+    pla                                                               // bebc: 68          h
     tay                                                               // bebd: a8          .
     pla                                                               // bebe: 68          h
     sta (l00ba),y                                                     // bebf: 91 ba       ..
@@ -10668,7 +10696,8 @@ sub_cbec2
 service_handler
     cmp #service_claim_absolute_workspace                             // bec8: c9 01       ..
     bne cbee0                                                         // beca: d0 14       ..
-    pha                                                               // becc: 48          H              // push A,Y onto the stack
+    // push A,Y onto the stack
+    pha                                                               // becc: 48          H
     tya                                                               // becd: 98          .
     pha                                                               // bece: 48          H
     lda #osbyte_issue_service_request                                 // becf: a9 8f       ..

--- a/examples/known_good/dfs226b_acme.asm
+++ b/examples/known_good/dfs226b_acme.asm
@@ -404,7 +404,8 @@ print_inline_l809f_top_bit_clear
     pla                                                               ; 207c: 68          h   :807c[1]
     sta l00af                                                         ; 207d: 85 af       ..  :807d[1]
     lda l00b3                                                         ; 207f: a5 b3       ..  :807f[1]
-    pha                                                               ; 2081: 48          H   :8081[1]   ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 2081: 48          H   :8081[1]
     tya                                                               ; 2082: 98          .   :8082[1]
     pha                                                               ; 2083: 48          H   :8083[1]
     ldy #0                                                            ; 2084: a0 00       ..  :8084[1]
@@ -418,7 +419,8 @@ loop_c8086
 
 ; $2093 referenced 1 time by $808b[1]
 c8093
-    pla                                                               ; 2093: 68          h   :8093[1]   ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 2093: 68          h   :8093[1]
     tay                                                               ; 2094: a8          .   :8094[1]
     pla                                                               ; 2095: 68          h   :8095[1]
 ; $2096 referenced 1 time by $806d[1]
@@ -442,7 +444,8 @@ c809f
     pha                                                               ; 20a9: 48          H   :80a9[1]
     ora #$10                                                          ; 20aa: 09 10       ..  :80aa[1]
     jsr sub_c9ad3                                                     ; 20ac: 20 d3 9a     .. :80ac[1]
-    pla                                                               ; 20af: 68          h   :80af[1]   ; pull A,X from the stack
+    ; pull A,X from the stack
+    pla                                                               ; 20af: 68          h   :80af[1]
     tax                                                               ; 20b0: aa          .   :80b0[1]
     pla                                                               ; 20b1: 68          h   :80b1[1]
     jsr osasci                                                        ; 20b2: 20 e3 ff     .. :80b2[1]   ; Write character
@@ -1068,7 +1071,8 @@ return_6
 
 ; $23e3 referenced 29 times by $809f[1], $8174[1], $82bb[1], $833a[1], $8380[1], $8386[1], $8951[1], $8a32[1], $96c3[1], $97cd[1], $993b[1], $99f3[1], $9a0f[1], $9a32[1], $9a63[1], $9ac8[1], $9ad8[1], $9b51[1], $9bf2[1], $9c10[1], $9d9b[1], $9f7c[1], $9f82[1], $a06c[1], $a190[1], $a1b4[1], $a379[1], $a384[1], $ac72[1]
 sub_c83e3
-    pha                                                               ; 23e3: 48          H   :83e3[1]   ; push A,X,Y onto the stack
+    ; push A,X,Y onto the stack
+    pha                                                               ; 23e3: 48          H   :83e3[1]
     txa                                                               ; 23e4: 8a          .   :83e4[1]
     pha                                                               ; 23e5: 48          H   :83e5[1]
     tya                                                               ; 23e6: 98          .   :83e6[1]
@@ -1099,7 +1103,8 @@ loop_c83fa
     pla                                                               ; 2405: 68          h   :8405[1]
 ; $2406 referenced 1 time by $8418[1]
 loop_c8406
-    pla                                                               ; 2406: 68          h   :8406[1]   ; pull A,X,Y from the stack
+    ; pull A,X,Y from the stack
+    pla                                                               ; 2406: 68          h   :8406[1]
     tay                                                               ; 2407: a8          .   :8407[1]
     pla                                                               ; 2408: 68          h   :8408[1]
     tax                                                               ; 2409: aa          .   :8409[1]
@@ -1108,7 +1113,8 @@ loop_c8406
 
 ; $240c referenced 5 times by $841b[1], $9785[1], $9c16[1], $9e94[1], $aadd[1]
 sub_c840c
-    pha                                                               ; 240c: 48          H   :840c[1]   ; push A,X,Y onto the stack
+    ; push A,X,Y onto the stack
+    pha                                                               ; 240c: 48          H   :840c[1]
     txa                                                               ; 240d: 8a          .   :840d[1]
     pha                                                               ; 240e: 48          H   :840e[1]
     tya                                                               ; 240f: 98          .   :840f[1]
@@ -3773,7 +3779,8 @@ sub_c93c5
     tay                                                               ; 33c5: a8          .   :93c5[1]
     lda (l00b2),y                                                     ; 33c6: b1 b2       ..  :93c6[1]
     tax                                                               ; 33c8: aa          .   :93c8[1]
-    tya                                                               ; 33c9: 98          .   :93c9[1]   ; add 18 to Y
+    ; add 18 to Y
+    tya                                                               ; 33c9: 98          .   :93c9[1]
     clc                                                               ; 33ca: 18          .   :93ca[1]
     adc #$12                                                          ; 33cb: 69 12       i.  :93cb[1]
     tay                                                               ; 33cd: a8          .   :93cd[1]
@@ -4218,7 +4225,8 @@ return_28
 c9683
     cmp #service_claim_private_workspace                              ; 3683: c9 02       ..  :9683[1]
     bne c96c3                                                         ; 3685: d0 3c       .<  :9685[1]
-    pha                                                               ; 3687: 48          H   :9687[1]   ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 3687: 48          H   :9687[1]
     tya                                                               ; 3688: 98          .   :9688[1]
     pha                                                               ; 3689: 48          H   :9689[1]
     sta l00b1                                                         ; 368a: 85 b1       ..  :968a[1]
@@ -5370,13 +5378,15 @@ c9d89
 
 ; $3d8e referenced 6 times by $956f[1], $9714[1], $97d0[1], $9d72[1], $9daa[1], $9db8[1]
 zero_stacked_XXX
-    pha                                                               ; 3d8e: 48          H   :9d8e[1]   ; push A,X onto the stack
+    ; push A,X onto the stack
+    pha                                                               ; 3d8e: 48          H   :9d8e[1]
     txa                                                               ; 3d8f: 8a          .   :9d8f[1]
     pha                                                               ; 3d90: 48          H   :9d90[1]
     lda #0                                                            ; 3d91: a9 00       ..  :9d91[1]
     tsx                                                               ; 3d93: ba          .   :9d93[1]
     sta l0109,x                                                       ; 3d94: 9d 09 01    ... :9d94[1]
-    pla                                                               ; 3d97: 68          h   :9d97[1]   ; pull A,X from the stack
+    ; pull A,X from the stack
+    pla                                                               ; 3d97: 68          h   :9d97[1]
     tax                                                               ; 3d98: aa          .   :9d98[1]
     pla                                                               ; 3d99: 68          h   :9d99[1]
     rts                                                               ; 3d9a: 60          `   :9d9a[1]
@@ -5521,7 +5531,8 @@ sub_c9e54
 return_40
     rts                                                               ; 3e5c: 60          `   :9e5c[1]
 
-    pha                                                               ; 3e5d: 48          H   :9e5d[1]   ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 3e5d: 48          H   :9e5d[1]
     tya                                                               ; 3e5e: 98          .   :9e5e[1]
     pha                                                               ; 3e5f: 48          H   :9e5f[1]
     txa                                                               ; 3e60: 8a          .   :9e60[1]
@@ -5538,7 +5549,8 @@ c9e6f
     ldx #0                                                            ; 3e6f: a2 00       ..  :9e6f[1]
 ; $3e71 referenced 1 time by $9e6d[1]
 c9e71
-    pla                                                               ; 3e71: 68          h   :9e71[1]   ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 3e71: 68          h   :9e71[1]
     tay                                                               ; 3e72: a8          .   :9e72[1]
     pla                                                               ; 3e73: 68          h   :9e73[1]
 ; $3e74 referenced 1 time by $9e7b[1]
@@ -7143,7 +7155,8 @@ print_inline_osasci_top_bit_clear
     pla                                                               ; 49a1: 68          h   :a9a1[1]
     sta l00af                                                         ; 49a2: 85 af       ..  :a9a2[1]
     lda l00b3                                                         ; 49a4: a5 b3       ..  :a9a4[1]
-    pha                                                               ; 49a6: 48          H   :a9a6[1]   ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 49a6: 48          H   :a9a6[1]
     tya                                                               ; 49a7: 98          .   :a9a7[1]
     pha                                                               ; 49a8: 48          H   :a9a8[1]
     ldy #0                                                            ; 49a9: a0 00       ..  :a9a9[1]
@@ -7157,7 +7170,8 @@ loop_ca9ab
 
 ; $49b8 referenced 1 time by $a9b0[1]
 ca9b8
-    pla                                                               ; 49b8: 68          h   :a9b8[1]   ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 49b8: 68          h   :a9b8[1]
     tay                                                               ; 49b9: a8          .   :a9b9[1]
     pla                                                               ; 49ba: 68          h   :a9ba[1]
     clc                                                               ; 49bb: 18          .   :a9bb[1]
@@ -8398,7 +8412,8 @@ general_service_handler
     lda l00b8                                                         ; 51b6: a5 b8       ..  :b1b6[1]
     pha                                                               ; 51b8: 48          H   :b1b8[1]
     lda l00b9                                                         ; 51b9: a5 b9       ..  :b1b9[1]
-    pha                                                               ; 51bb: 48          H   :b1bb[1]   ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 51bb: 48          H   :b1bb[1]
     tya                                                               ; 51bc: 98          .   :b1bc[1]
     pha                                                               ; 51bd: 48          H   :b1bd[1]
     txa                                                               ; 51be: 8a          .   :b1be[1]
@@ -8450,7 +8465,8 @@ cb1fc
     jsr sub_cb882                                                     ; 5200: 20 82 b8     .. :b200[1]
 ; $5203 referenced 10 times by $b1c6[1], $b1db[1], $b1df[1], $b219[1], $b21e[1], $b228[1], $b22c[1], $b262[1], $b26a[1], $b280[1]
 cb203
-    pla                                                               ; 5203: 68          h   :b203[1]   ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 5203: 68          h   :b203[1]
     tay                                                               ; 5204: a8          .   :b204[1]
     pla                                                               ; 5205: 68          h   :b205[1]
     sta l00b9                                                         ; 5206: 85 b9       ..  :b206[1]
@@ -8769,7 +8785,8 @@ cb3ba
 cb3de
     lda #osbyte_read_himem                                            ; 53de: a9 84       ..  :b3de[1]
     jsr osbyte                                                        ; 53e0: 20 f4 ff     .. :b3e0[1]   ; Read top of user memory (HIMEM)
-    tya                                                               ; 53e3: 98          .   :b3e3[1]   ; push Y,X onto the stack; X and Y contain the address of HIMEM (low, high)
+    ; push Y,X onto the stack
+    tya                                                               ; 53e3: 98          .   :b3e3[1]   ; X and Y contain the address of HIMEM (low, high)
     pha                                                               ; 53e4: 48          H   :b3e4[1]
     txa                                                               ; 53e5: 8a          .   :b3e5[1]
     pha                                                               ; 53e6: 48          H   :b3e6[1]
@@ -8997,7 +9014,8 @@ cb534
     lda l00bb                                                         ; 5548: a5 bb       ..  :b548[1]
     iny                                                               ; 554a: c8          .   :b54a[1]   ; Y=$fc
     adc (l00b8),y                                                     ; 554b: 71 b8       q.  :b54b[1]
-    pha                                                               ; 554d: 48          H   :b54d[1]   ; push A,X onto the stack
+    ; push A,X onto the stack
+    pha                                                               ; 554d: 48          H   :b54d[1]
     txa                                                               ; 554e: 8a          .   :b54e[1]
     pha                                                               ; 554f: 48          H   :b54f[1]
     lda #$ff                                                          ; 5550: a9 ff       ..  :b550[1]
@@ -9370,7 +9388,8 @@ cb736
 ; $5745 referenced 5 times by $b369[1], $b8b7[1], $b8d1[1], $bc78[1], $bc9e[1]
 sub_cb745
     sta l00bf                                                         ; 5745: 85 bf       ..  :b745[1]
-    txa                                                               ; 5747: 8a          .   :b747[1]   ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; 5747: 8a          .   :b747[1]
     pha                                                               ; 5748: 48          H   :b748[1]
     tya                                                               ; 5749: 98          .   :b749[1]
     pha                                                               ; 574a: 48          H   :b74a[1]
@@ -9393,7 +9412,8 @@ loop_cb75a
     tay                                                               ; 5764: a8          .   :b764[1]
     lda l00bf                                                         ; 5765: a5 bf       ..  :b765[1]
     jsr sub_cb771                                                     ; 5767: 20 71 b7     q. :b767[1]
-    pla                                                               ; 576a: 68          h   :b76a[1]   ; pull X,Y from the stack
+    ; pull X,Y from the stack
+    pla                                                               ; 576a: 68          h   :b76a[1]
     tay                                                               ; 576b: a8          .   :b76b[1]
     pla                                                               ; 576c: 68          h   :b76c[1]
     tax                                                               ; 576d: aa          .   :b76d[1]
@@ -9450,7 +9470,8 @@ loop_cb7be
     lda romsel_copy                                                   ; 57c6: a5 f4       ..  :b7c6[1]
     pha                                                               ; 57c8: 48          H   :b7c8[1]
     lda #1                                                            ; 57c9: a9 01       ..  :b7c9[1]
-    pha                                                               ; 57cb: 48          H   :b7cb[1]   ; push A,X onto the stack
+    ; push A,X onto the stack
+    pha                                                               ; 57cb: 48          H   :b7cb[1]
     txa                                                               ; 57cc: 8a          .   :b7cc[1]
     pha                                                               ; 57cd: 48          H   :b7cd[1]
     lda l00b0                                                         ; 57ce: a5 b0       ..  :b7ce[1]
@@ -9517,7 +9538,8 @@ cb7ed
 
 ; $582b referenced 16 times by $b1c1[1], $b2c8[1], $b2e7[1], $b32c[1], $b35a[1], $b3b0[1], $b3ec[1], $b429[1], $b4a3[1], $b573[1], $b5ca[1], $b5e8[1], $b604[1], $b611[1], $b86b[1], $beb5[1]
 cb82b
-    php                                                               ; 582b: 08          .   :b82b[1]   ; push flags,A,X onto the stack
+    ; push flags,A,X onto the stack
+    php                                                               ; 582b: 08          .   :b82b[1]
     pha                                                               ; 582c: 48          H   :b82c[1]
     txa                                                               ; 582d: 8a          .   :b82d[1]
     pha                                                               ; 582e: 48          H   :b82e[1]
@@ -9526,7 +9548,8 @@ cb82b
     ldx romsel_copy                                                   ; 5833: a6 f4       ..  :b833[1]
     lda l0df0,x                                                       ; 5835: bd f0 0d    ... :b835[1]
     sta l00b9                                                         ; 5838: 85 b9       ..  :b838[1]
-    pla                                                               ; 583a: 68          h   :b83a[1]   ; pull flags,A,X from the stack
+    ; pull flags,A,X from the stack
+    pla                                                               ; 583a: 68          h   :b83a[1]
     tax                                                               ; 583b: aa          .   :b83b[1]
     pla                                                               ; 583c: 68          h   :b83c[1]
     plp                                                               ; 583d: 28          (   :b83d[1]
@@ -9564,13 +9587,15 @@ sub_cb850
 
 ; $585d referenced 8 times by $b2f2[1], $b340[1], $b406[1], $b63f[1], $b66e[1], $b7a7[1], $be64[1], $be9d[1]
 sub_cb85d
-    pha                                                               ; 585d: 48          H   :b85d[1]   ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 585d: 48          H   :b85d[1]
     tya                                                               ; 585e: 98          .   :b85e[1]
     pha                                                               ; 585f: 48          H   :b85f[1]
     ldy #$ee                                                          ; 5860: a0 ee       ..  :b860[1]
     lda (l00b8),y                                                     ; 5862: b1 b8       ..  :b862[1]
     sta l00b8                                                         ; 5864: 85 b8       ..  :b864[1]
-    pla                                                               ; 5866: 68          h   :b866[1]   ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 5866: 68          h   :b866[1]
     tay                                                               ; 5867: a8          .   :b867[1]
     pla                                                               ; 5868: 68          h   :b868[1]
     bit l00b8                                                         ; 5869: 24 b8       $.  :b869[1]
@@ -9704,7 +9729,8 @@ lb980
 
 ; $5986 referenced 3 times by $b8d4[1], $bc49[1], $bcb2[1]
 sub_cb986
-    txa                                                               ; 5986: 8a          .   :b986[1]   ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; 5986: 8a          .   :b986[1]
     pha                                                               ; 5987: 48          H   :b987[1]
     tya                                                               ; 5988: 98          .   :b988[1]
     pha                                                               ; 5989: 48          H   :b989[1]
@@ -9758,7 +9784,8 @@ loop_cb9d1
     clc                                                               ; 59d1: 18          .   :b9d1[1]
 ; $59d2 referenced 1 time by $b9f3[1]
 cb9d2
-    pla                                                               ; 59d2: 68          h   :b9d2[1]   ; pull X,Y from the stack
+    ; pull X,Y from the stack
+    pla                                                               ; 59d2: 68          h   :b9d2[1]
     tay                                                               ; 59d3: a8          .   :b9d3[1]
     pla                                                               ; 59d4: 68          h   :b9d4[1]
     tax                                                               ; 59d5: aa          .   :b9d5[1]
@@ -10646,7 +10673,8 @@ loop_cbeab
     jsr cb82b                                                         ; 5eb5: 20 2b b8     +. :beb5[1]
     stx l00ba                                                         ; 5eb8: 86 ba       ..  :beb8[1]
     sty l00bb                                                         ; 5eba: 84 bb       ..  :beba[1]
-    pla                                                               ; 5ebc: 68          h   :bebc[1]   ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 5ebc: 68          h   :bebc[1]
     tay                                                               ; 5ebd: a8          .   :bebd[1]
     pla                                                               ; 5ebe: 68          h   :bebe[1]
     sta (l00ba),y                                                     ; 5ebf: 91 ba       ..  :bebf[1]
@@ -10664,7 +10692,8 @@ sub_cbec2
 service_handler
     cmp #service_claim_absolute_workspace                             ; 5ec8: c9 01       ..  :bec8[1]
     bne cbee0                                                         ; 5eca: d0 14       ..  :beca[1]
-    pha                                                               ; 5ecc: 48          H   :becc[1]   ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 5ecc: 48          H   :becc[1]
     tya                                                               ; 5ecd: 98          .   :becd[1]
     pha                                                               ; 5ece: 48          H   :bece[1]
     lda #osbyte_issue_service_request                                 ; 5ecf: a9 8f       ..  :becf[1]

--- a/examples/known_good/dfs226b_beebasm.asm
+++ b/examples/known_good/dfs226b_beebasm.asm
@@ -404,7 +404,8 @@ l8004 = service_entry+1
     pla                                                               ; 207c: 68          h   :807c[1]
     sta l00af                                                         ; 207d: 85 af       ..  :807d[1]
     lda l00b3                                                         ; 207f: a5 b3       ..  :807f[1]
-    pha                                                               ; 2081: 48          H   :8081[1]   ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 2081: 48          H   :8081[1]
     tya                                                               ; 2082: 98          .   :8082[1]
     pha                                                               ; 2083: 48          H   :8083[1]
     ldy #0                                                            ; 2084: a0 00       ..  :8084[1]
@@ -418,7 +419,8 @@ l8004 = service_entry+1
 
 ; &2093 referenced 1 time by &808b[1]
 .c8093
-    pla                                                               ; 2093: 68          h   :8093[1]   ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 2093: 68          h   :8093[1]
     tay                                                               ; 2094: a8          .   :8094[1]
     pla                                                               ; 2095: 68          h   :8095[1]
 ; &2096 referenced 1 time by &806d[1]
@@ -442,7 +444,8 @@ l8004 = service_entry+1
     pha                                                               ; 20a9: 48          H   :80a9[1]
     ora #&10                                                          ; 20aa: 09 10       ..  :80aa[1]
     jsr sub_c9ad3                                                     ; 20ac: 20 d3 9a     .. :80ac[1]
-    pla                                                               ; 20af: 68          h   :80af[1]   ; pull A,X from the stack
+    ; pull A,X from the stack
+    pla                                                               ; 20af: 68          h   :80af[1]
     tax                                                               ; 20b0: aa          .   :80b0[1]
     pla                                                               ; 20b1: 68          h   :80b1[1]
     jsr osasci                                                        ; 20b2: 20 e3 ff     .. :80b2[1]   ; Write character
@@ -1068,7 +1071,8 @@ l8004 = service_entry+1
 
 ; &23e3 referenced 29 times by &809f[1], &8174[1], &82bb[1], &833a[1], &8380[1], &8386[1], &8951[1], &8a32[1], &96c3[1], &97cd[1], &993b[1], &99f3[1], &9a0f[1], &9a32[1], &9a63[1], &9ac8[1], &9ad8[1], &9b51[1], &9bf2[1], &9c10[1], &9d9b[1], &9f7c[1], &9f82[1], &a06c[1], &a190[1], &a1b4[1], &a379[1], &a384[1], &ac72[1]
 .sub_c83e3
-    pha                                                               ; 23e3: 48          H   :83e3[1]   ; push A,X,Y onto the stack
+    ; push A,X,Y onto the stack
+    pha                                                               ; 23e3: 48          H   :83e3[1]
     txa                                                               ; 23e4: 8a          .   :83e4[1]
     pha                                                               ; 23e5: 48          H   :83e5[1]
     tya                                                               ; 23e6: 98          .   :83e6[1]
@@ -1099,7 +1103,8 @@ l8004 = service_entry+1
     pla                                                               ; 2405: 68          h   :8405[1]
 ; &2406 referenced 1 time by &8418[1]
 .loop_c8406
-    pla                                                               ; 2406: 68          h   :8406[1]   ; pull A,X,Y from the stack
+    ; pull A,X,Y from the stack
+    pla                                                               ; 2406: 68          h   :8406[1]
     tay                                                               ; 2407: a8          .   :8407[1]
     pla                                                               ; 2408: 68          h   :8408[1]
     tax                                                               ; 2409: aa          .   :8409[1]
@@ -1108,7 +1113,8 @@ l8004 = service_entry+1
 
 ; &240c referenced 5 times by &841b[1], &9785[1], &9c16[1], &9e94[1], &aadd[1]
 .sub_c840c
-    pha                                                               ; 240c: 48          H   :840c[1]   ; push A,X,Y onto the stack
+    ; push A,X,Y onto the stack
+    pha                                                               ; 240c: 48          H   :840c[1]
     txa                                                               ; 240d: 8a          .   :840d[1]
     pha                                                               ; 240e: 48          H   :840e[1]
     tya                                                               ; 240f: 98          .   :840f[1]
@@ -3828,7 +3834,8 @@ nmi_XXX5 = l0d1f+1
     tay                                                               ; 33c5: a8          .   :93c5[1]
     lda (l00b2),y                                                     ; 33c6: b1 b2       ..  :93c6[1]
     tax                                                               ; 33c8: aa          .   :93c8[1]
-    tya                                                               ; 33c9: 98          .   :93c9[1]   ; add 18 to Y
+    ; add 18 to Y
+    tya                                                               ; 33c9: 98          .   :93c9[1]
     clc                                                               ; 33ca: 18          .   :93ca[1]
     adc #&12                                                          ; 33cb: 69 12       i.  :93cb[1]
     tay                                                               ; 33cd: a8          .   :93cd[1]
@@ -4273,7 +4280,8 @@ nmi_XXX5 = l0d1f+1
 .c9683
     cmp #service_claim_private_workspace                              ; 3683: c9 02       ..  :9683[1]
     bne c96c3                                                         ; 3685: d0 3c       .<  :9685[1]
-    pha                                                               ; 3687: 48          H   :9687[1]   ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 3687: 48          H   :9687[1]
     tya                                                               ; 3688: 98          .   :9688[1]
     pha                                                               ; 3689: 48          H   :9689[1]
     sta l00b1                                                         ; 368a: 85 b1       ..  :968a[1]
@@ -5425,13 +5433,15 @@ nmi_XXX5 = l0d1f+1
 
 ; &3d8e referenced 6 times by &956f[1], &9714[1], &97d0[1], &9d72[1], &9daa[1], &9db8[1]
 .zero_stacked_XXX
-    pha                                                               ; 3d8e: 48          H   :9d8e[1]   ; push A,X onto the stack
+    ; push A,X onto the stack
+    pha                                                               ; 3d8e: 48          H   :9d8e[1]
     txa                                                               ; 3d8f: 8a          .   :9d8f[1]
     pha                                                               ; 3d90: 48          H   :9d90[1]
     lda #0                                                            ; 3d91: a9 00       ..  :9d91[1]
     tsx                                                               ; 3d93: ba          .   :9d93[1]
     sta l0109,x                                                       ; 3d94: 9d 09 01    ... :9d94[1]
-    pla                                                               ; 3d97: 68          h   :9d97[1]   ; pull A,X from the stack
+    ; pull A,X from the stack
+    pla                                                               ; 3d97: 68          h   :9d97[1]
     tax                                                               ; 3d98: aa          .   :9d98[1]
     pla                                                               ; 3d99: 68          h   :9d99[1]
     rts                                                               ; 3d9a: 60          `   :9d9a[1]
@@ -5576,7 +5586,8 @@ nmi_XXX5 = l0d1f+1
 .return_40
     rts                                                               ; 3e5c: 60          `   :9e5c[1]
 
-    pha                                                               ; 3e5d: 48          H   :9e5d[1]   ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 3e5d: 48          H   :9e5d[1]
     tya                                                               ; 3e5e: 98          .   :9e5e[1]
     pha                                                               ; 3e5f: 48          H   :9e5f[1]
     txa                                                               ; 3e60: 8a          .   :9e60[1]
@@ -5593,7 +5604,8 @@ nmi_XXX5 = l0d1f+1
     ldx #0                                                            ; 3e6f: a2 00       ..  :9e6f[1]
 ; &3e71 referenced 1 time by &9e6d[1]
 .c9e71
-    pla                                                               ; 3e71: 68          h   :9e71[1]   ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 3e71: 68          h   :9e71[1]
     tay                                                               ; 3e72: a8          .   :9e72[1]
     pla                                                               ; 3e73: 68          h   :9e73[1]
 ; &3e74 referenced 1 time by &9e7b[1]
@@ -7198,7 +7210,8 @@ nmi_XXX5 = l0d1f+1
     pla                                                               ; 49a1: 68          h   :a9a1[1]
     sta l00af                                                         ; 49a2: 85 af       ..  :a9a2[1]
     lda l00b3                                                         ; 49a4: a5 b3       ..  :a9a4[1]
-    pha                                                               ; 49a6: 48          H   :a9a6[1]   ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 49a6: 48          H   :a9a6[1]
     tya                                                               ; 49a7: 98          .   :a9a7[1]
     pha                                                               ; 49a8: 48          H   :a9a8[1]
     ldy #0                                                            ; 49a9: a0 00       ..  :a9a9[1]
@@ -7212,7 +7225,8 @@ nmi_XXX5 = l0d1f+1
 
 ; &49b8 referenced 1 time by &a9b0[1]
 .ca9b8
-    pla                                                               ; 49b8: 68          h   :a9b8[1]   ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 49b8: 68          h   :a9b8[1]
     tay                                                               ; 49b9: a8          .   :a9b9[1]
     pla                                                               ; 49ba: 68          h   :a9ba[1]
     clc                                                               ; 49bb: 18          .   :a9bb[1]
@@ -8508,7 +8522,8 @@ jump_address_low = sub_c0050+1
     lda l00b8                                                         ; 51b6: a5 b8       ..  :b1b6[1]
     pha                                                               ; 51b8: 48          H   :b1b8[1]
     lda l00b9                                                         ; 51b9: a5 b9       ..  :b1b9[1]
-    pha                                                               ; 51bb: 48          H   :b1bb[1]   ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 51bb: 48          H   :b1bb[1]
     tya                                                               ; 51bc: 98          .   :b1bc[1]
     pha                                                               ; 51bd: 48          H   :b1bd[1]
     txa                                                               ; 51be: 8a          .   :b1be[1]
@@ -8560,7 +8575,8 @@ jump_address_low = sub_c0050+1
     jsr sub_cb882                                                     ; 5200: 20 82 b8     .. :b200[1]
 ; &5203 referenced 10 times by &b1c6[1], &b1db[1], &b1df[1], &b219[1], &b21e[1], &b228[1], &b22c[1], &b262[1], &b26a[1], &b280[1]
 .cb203
-    pla                                                               ; 5203: 68          h   :b203[1]   ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 5203: 68          h   :b203[1]
     tay                                                               ; 5204: a8          .   :b204[1]
     pla                                                               ; 5205: 68          h   :b205[1]
     sta l00b9                                                         ; 5206: 85 b9       ..  :b206[1]
@@ -8879,7 +8895,8 @@ jump_address_low = sub_c0050+1
 .cb3de
     lda #osbyte_read_himem                                            ; 53de: a9 84       ..  :b3de[1]
     jsr osbyte                                                        ; 53e0: 20 f4 ff     .. :b3e0[1]   ; Read top of user memory (HIMEM)
-    tya                                                               ; 53e3: 98          .   :b3e3[1]   ; push Y,X onto the stack; X and Y contain the address of HIMEM (low, high)
+    ; push Y,X onto the stack
+    tya                                                               ; 53e3: 98          .   :b3e3[1]   ; X and Y contain the address of HIMEM (low, high)
     pha                                                               ; 53e4: 48          H   :b3e4[1]
     txa                                                               ; 53e5: 8a          .   :b3e5[1]
     pha                                                               ; 53e6: 48          H   :b3e6[1]
@@ -9107,7 +9124,8 @@ jump_address_low = sub_c0050+1
     lda l00bb                                                         ; 5548: a5 bb       ..  :b548[1]
     iny                                                               ; 554a: c8          .   :b54a[1]   ; Y=&fc
     adc (l00b8),y                                                     ; 554b: 71 b8       q.  :b54b[1]
-    pha                                                               ; 554d: 48          H   :b54d[1]   ; push A,X onto the stack
+    ; push A,X onto the stack
+    pha                                                               ; 554d: 48          H   :b54d[1]
     txa                                                               ; 554e: 8a          .   :b54e[1]
     pha                                                               ; 554f: 48          H   :b54f[1]
     lda #&ff                                                          ; 5550: a9 ff       ..  :b550[1]
@@ -9480,7 +9498,8 @@ lb6ce = sub_cb6cd+1
 ; &5745 referenced 5 times by &b369[1], &b8b7[1], &b8d1[1], &bc78[1], &bc9e[1]
 .sub_cb745
     sta l00bf                                                         ; 5745: 85 bf       ..  :b745[1]
-    txa                                                               ; 5747: 8a          .   :b747[1]   ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; 5747: 8a          .   :b747[1]
     pha                                                               ; 5748: 48          H   :b748[1]
     tya                                                               ; 5749: 98          .   :b749[1]
     pha                                                               ; 574a: 48          H   :b74a[1]
@@ -9503,7 +9522,8 @@ lb6ce = sub_cb6cd+1
     tay                                                               ; 5764: a8          .   :b764[1]
     lda l00bf                                                         ; 5765: a5 bf       ..  :b765[1]
     jsr sub_cb771                                                     ; 5767: 20 71 b7     q. :b767[1]
-    pla                                                               ; 576a: 68          h   :b76a[1]   ; pull X,Y from the stack
+    ; pull X,Y from the stack
+    pla                                                               ; 576a: 68          h   :b76a[1]
     tay                                                               ; 576b: a8          .   :b76b[1]
     pla                                                               ; 576c: 68          h   :b76c[1]
     tax                                                               ; 576d: aa          .   :b76d[1]
@@ -9560,7 +9580,8 @@ lb6ce = sub_cb6cd+1
     lda romsel_copy                                                   ; 57c6: a5 f4       ..  :b7c6[1]
     pha                                                               ; 57c8: 48          H   :b7c8[1]
     lda #1                                                            ; 57c9: a9 01       ..  :b7c9[1]
-    pha                                                               ; 57cb: 48          H   :b7cb[1]   ; push A,X onto the stack
+    ; push A,X onto the stack
+    pha                                                               ; 57cb: 48          H   :b7cb[1]
     txa                                                               ; 57cc: 8a          .   :b7cc[1]
     pha                                                               ; 57cd: 48          H   :b7cd[1]
     lda l00b0                                                         ; 57ce: a5 b0       ..  :b7ce[1]
@@ -9627,7 +9648,8 @@ lb6ce = sub_cb6cd+1
 
 ; &582b referenced 16 times by &b1c1[1], &b2c8[1], &b2e7[1], &b32c[1], &b35a[1], &b3b0[1], &b3ec[1], &b429[1], &b4a3[1], &b573[1], &b5ca[1], &b5e8[1], &b604[1], &b611[1], &b86b[1], &beb5[1]
 .cb82b
-    php                                                               ; 582b: 08          .   :b82b[1]   ; push flags,A,X onto the stack
+    ; push flags,A,X onto the stack
+    php                                                               ; 582b: 08          .   :b82b[1]
     pha                                                               ; 582c: 48          H   :b82c[1]
     txa                                                               ; 582d: 8a          .   :b82d[1]
     pha                                                               ; 582e: 48          H   :b82e[1]
@@ -9636,7 +9658,8 @@ lb6ce = sub_cb6cd+1
     ldx romsel_copy                                                   ; 5833: a6 f4       ..  :b833[1]
     lda l0df0,x                                                       ; 5835: bd f0 0d    ... :b835[1]
     sta l00b9                                                         ; 5838: 85 b9       ..  :b838[1]
-    pla                                                               ; 583a: 68          h   :b83a[1]   ; pull flags,A,X from the stack
+    ; pull flags,A,X from the stack
+    pla                                                               ; 583a: 68          h   :b83a[1]
     tax                                                               ; 583b: aa          .   :b83b[1]
     pla                                                               ; 583c: 68          h   :b83c[1]
     plp                                                               ; 583d: 28          (   :b83d[1]
@@ -9674,13 +9697,15 @@ lb6ce = sub_cb6cd+1
 
 ; &585d referenced 8 times by &b2f2[1], &b340[1], &b406[1], &b63f[1], &b66e[1], &b7a7[1], &be64[1], &be9d[1]
 .sub_cb85d
-    pha                                                               ; 585d: 48          H   :b85d[1]   ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 585d: 48          H   :b85d[1]
     tya                                                               ; 585e: 98          .   :b85e[1]
     pha                                                               ; 585f: 48          H   :b85f[1]
     ldy #&ee                                                          ; 5860: a0 ee       ..  :b860[1]
     lda (l00b8),y                                                     ; 5862: b1 b8       ..  :b862[1]
     sta l00b8                                                         ; 5864: 85 b8       ..  :b864[1]
-    pla                                                               ; 5866: 68          h   :b866[1]   ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 5866: 68          h   :b866[1]
     tay                                                               ; 5867: a8          .   :b867[1]
     pla                                                               ; 5868: 68          h   :b868[1]
     bit l00b8                                                         ; 5869: 24 b8       $.  :b869[1]
@@ -9814,7 +9839,8 @@ lb6ce = sub_cb6cd+1
 
 ; &5986 referenced 3 times by &b8d4[1], &bc49[1], &bcb2[1]
 .sub_cb986
-    txa                                                               ; 5986: 8a          .   :b986[1]   ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; 5986: 8a          .   :b986[1]
     pha                                                               ; 5987: 48          H   :b987[1]
     tya                                                               ; 5988: 98          .   :b988[1]
     pha                                                               ; 5989: 48          H   :b989[1]
@@ -9868,7 +9894,8 @@ lb6ce = sub_cb6cd+1
     clc                                                               ; 59d1: 18          .   :b9d1[1]
 ; &59d2 referenced 1 time by &b9f3[1]
 .cb9d2
-    pla                                                               ; 59d2: 68          h   :b9d2[1]   ; pull X,Y from the stack
+    ; pull X,Y from the stack
+    pla                                                               ; 59d2: 68          h   :b9d2[1]
     tay                                                               ; 59d3: a8          .   :b9d3[1]
     pla                                                               ; 59d4: 68          h   :b9d4[1]
     tax                                                               ; 59d5: aa          .   :b9d5[1]
@@ -10756,7 +10783,8 @@ lb6ce = sub_cb6cd+1
     jsr cb82b                                                         ; 5eb5: 20 2b b8     +. :beb5[1]
     stx l00ba                                                         ; 5eb8: 86 ba       ..  :beb8[1]
     sty l00bb                                                         ; 5eba: 84 bb       ..  :beba[1]
-    pla                                                               ; 5ebc: 68          h   :bebc[1]   ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; 5ebc: 68          h   :bebc[1]
     tay                                                               ; 5ebd: a8          .   :bebd[1]
     pla                                                               ; 5ebe: 68          h   :bebe[1]
     sta (l00ba),y                                                     ; 5ebf: 91 ba       ..  :bebf[1]
@@ -10774,7 +10802,8 @@ lb6ce = sub_cb6cd+1
 .service_handler
     cmp #service_claim_absolute_workspace                             ; 5ec8: c9 01       ..  :bec8[1]
     bne cbee0                                                         ; 5eca: d0 14       ..  :beca[1]
-    pha                                                               ; 5ecc: 48          H   :becc[1]   ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; 5ecc: 48          H   :becc[1]
     tya                                                               ; 5ecd: 98          .   :becd[1]
     pha                                                               ; 5ece: 48          H   :bece[1]
     lda #osbyte_issue_service_request                                 ; 5ecf: a9 8f       ..  :becf[1]

--- a/examples/known_good/dfs226b_xa.asm
+++ b/examples/known_good/dfs226b_xa.asm
@@ -404,7 +404,8 @@ print_inline_l809f_top_bit_clear
     pla                                                               // 207c: 68          h   :807c[1]
     sta l00af                                                         // 207d: 85 af       ..  :807d[1]
     lda l00b3                                                         // 207f: a5 b3       ..  :807f[1]
-    pha                                                               // 2081: 48          H   :8081[1]   // push A,Y onto the stack
+    // push A,Y onto the stack
+    pha                                                               // 2081: 48          H   :8081[1]
     tya                                                               // 2082: 98          .   :8082[1]
     pha                                                               // 2083: 48          H   :8083[1]
     ldy #0                                                            // 2084: a0 00       ..  :8084[1]
@@ -418,7 +419,8 @@ loop_c8086
 
 // $2093 referenced 1 time by $808b[1]
 c8093
-    pla                                                               // 2093: 68          h   :8093[1]   // pull A,Y from the stack
+    // pull A,Y from the stack
+    pla                                                               // 2093: 68          h   :8093[1]
     tay                                                               // 2094: a8          .   :8094[1]
     pla                                                               // 2095: 68          h   :8095[1]
 // $2096 referenced 1 time by $806d[1]
@@ -442,7 +444,8 @@ c809f
     pha                                                               // 20a9: 48          H   :80a9[1]
     ora #$10                                                          // 20aa: 09 10       ..  :80aa[1]
     jsr sub_c9ad3                                                     // 20ac: 20 d3 9a     .. :80ac[1]
-    pla                                                               // 20af: 68          h   :80af[1]   // pull A,X from the stack
+    // pull A,X from the stack
+    pla                                                               // 20af: 68          h   :80af[1]
     tax                                                               // 20b0: aa          .   :80b0[1]
     pla                                                               // 20b1: 68          h   :80b1[1]
     jsr osasci                                                        // 20b2: 20 e3 ff     .. :80b2[1]   // Write character
@@ -1068,7 +1071,8 @@ return_6
 
 // $23e3 referenced 29 times by $809f[1], $8174[1], $82bb[1], $833a[1], $8380[1], $8386[1], $8951[1], $8a32[1], $96c3[1], $97cd[1], $993b[1], $99f3[1], $9a0f[1], $9a32[1], $9a63[1], $9ac8[1], $9ad8[1], $9b51[1], $9bf2[1], $9c10[1], $9d9b[1], $9f7c[1], $9f82[1], $a06c[1], $a190[1], $a1b4[1], $a379[1], $a384[1], $ac72[1]
 sub_c83e3
-    pha                                                               // 23e3: 48          H   :83e3[1]   // push A,X,Y onto the stack
+    // push A,X,Y onto the stack
+    pha                                                               // 23e3: 48          H   :83e3[1]
     txa                                                               // 23e4: 8a          .   :83e4[1]
     pha                                                               // 23e5: 48          H   :83e5[1]
     tya                                                               // 23e6: 98          .   :83e6[1]
@@ -1099,7 +1103,8 @@ loop_c83fa
     pla                                                               // 2405: 68          h   :8405[1]
 // $2406 referenced 1 time by $8418[1]
 loop_c8406
-    pla                                                               // 2406: 68          h   :8406[1]   // pull A,X,Y from the stack
+    // pull A,X,Y from the stack
+    pla                                                               // 2406: 68          h   :8406[1]
     tay                                                               // 2407: a8          .   :8407[1]
     pla                                                               // 2408: 68          h   :8408[1]
     tax                                                               // 2409: aa          .   :8409[1]
@@ -1108,7 +1113,8 @@ loop_c8406
 
 // $240c referenced 5 times by $841b[1], $9785[1], $9c16[1], $9e94[1], $aadd[1]
 sub_c840c
-    pha                                                               // 240c: 48          H   :840c[1]   // push A,X,Y onto the stack
+    // push A,X,Y onto the stack
+    pha                                                               // 240c: 48          H   :840c[1]
     txa                                                               // 240d: 8a          .   :840d[1]
     pha                                                               // 240e: 48          H   :840e[1]
     tya                                                               // 240f: 98          .   :840f[1]
@@ -3768,7 +3774,8 @@ sub_c93c5
     tay                                                               // 33c5: a8          .   :93c5[1]
     lda (l00b2),y                                                     // 33c6: b1 b2       ..  :93c6[1]
     tax                                                               // 33c8: aa          .   :93c8[1]
-    tya                                                               // 33c9: 98          .   :93c9[1]   // add 18 to Y
+    // add 18 to Y
+    tya                                                               // 33c9: 98          .   :93c9[1]
     clc                                                               // 33ca: 18          .   :93ca[1]
     adc #$12                                                          // 33cb: 69 12       i.  :93cb[1]
     tay                                                               // 33cd: a8          .   :93cd[1]
@@ -4213,7 +4220,8 @@ return_28
 c9683
     cmp #service_claim_private_workspace                              // 3683: c9 02       ..  :9683[1]
     bne c96c3                                                         // 3685: d0 3c       .<  :9685[1]
-    pha                                                               // 3687: 48          H   :9687[1]   // push A,Y onto the stack
+    // push A,Y onto the stack
+    pha                                                               // 3687: 48          H   :9687[1]
     tya                                                               // 3688: 98          .   :9688[1]
     pha                                                               // 3689: 48          H   :9689[1]
     sta l00b1                                                         // 368a: 85 b1       ..  :968a[1]
@@ -5365,13 +5373,15 @@ c9d89
 
 // $3d8e referenced 6 times by $956f[1], $9714[1], $97d0[1], $9d72[1], $9daa[1], $9db8[1]
 zero_stacked_XXX
-    pha                                                               // 3d8e: 48          H   :9d8e[1]   // push A,X onto the stack
+    // push A,X onto the stack
+    pha                                                               // 3d8e: 48          H   :9d8e[1]
     txa                                                               // 3d8f: 8a          .   :9d8f[1]
     pha                                                               // 3d90: 48          H   :9d90[1]
     lda #0                                                            // 3d91: a9 00       ..  :9d91[1]
     tsx                                                               // 3d93: ba          .   :9d93[1]
     sta l0109,x                                                       // 3d94: 9d 09 01    ... :9d94[1]
-    pla                                                               // 3d97: 68          h   :9d97[1]   // pull A,X from the stack
+    // pull A,X from the stack
+    pla                                                               // 3d97: 68          h   :9d97[1]
     tax                                                               // 3d98: aa          .   :9d98[1]
     pla                                                               // 3d99: 68          h   :9d99[1]
     rts                                                               // 3d9a: 60          `   :9d9a[1]
@@ -5516,7 +5526,8 @@ sub_c9e54
 return_40
     rts                                                               // 3e5c: 60          `   :9e5c[1]
 
-    pha                                                               // 3e5d: 48          H   :9e5d[1]   // push A,Y onto the stack
+    // push A,Y onto the stack
+    pha                                                               // 3e5d: 48          H   :9e5d[1]
     tya                                                               // 3e5e: 98          .   :9e5e[1]
     pha                                                               // 3e5f: 48          H   :9e5f[1]
     txa                                                               // 3e60: 8a          .   :9e60[1]
@@ -5533,7 +5544,8 @@ c9e6f
     ldx #0                                                            // 3e6f: a2 00       ..  :9e6f[1]
 // $3e71 referenced 1 time by $9e6d[1]
 c9e71
-    pla                                                               // 3e71: 68          h   :9e71[1]   // pull A,Y from the stack
+    // pull A,Y from the stack
+    pla                                                               // 3e71: 68          h   :9e71[1]
     tay                                                               // 3e72: a8          .   :9e72[1]
     pla                                                               // 3e73: 68          h   :9e73[1]
 // $3e74 referenced 1 time by $9e7b[1]
@@ -7138,7 +7150,8 @@ print_inline_osasci_top_bit_clear
     pla                                                               // 49a1: 68          h   :a9a1[1]
     sta l00af                                                         // 49a2: 85 af       ..  :a9a2[1]
     lda l00b3                                                         // 49a4: a5 b3       ..  :a9a4[1]
-    pha                                                               // 49a6: 48          H   :a9a6[1]   // push A,Y onto the stack
+    // push A,Y onto the stack
+    pha                                                               // 49a6: 48          H   :a9a6[1]
     tya                                                               // 49a7: 98          .   :a9a7[1]
     pha                                                               // 49a8: 48          H   :a9a8[1]
     ldy #0                                                            // 49a9: a0 00       ..  :a9a9[1]
@@ -7152,7 +7165,8 @@ loop_ca9ab
 
 // $49b8 referenced 1 time by $a9b0[1]
 ca9b8
-    pla                                                               // 49b8: 68          h   :a9b8[1]   // pull A,Y from the stack
+    // pull A,Y from the stack
+    pla                                                               // 49b8: 68          h   :a9b8[1]
     tay                                                               // 49b9: a8          .   :a9b9[1]
     pla                                                               // 49ba: 68          h   :a9ba[1]
     clc                                                               // 49bb: 18          .   :a9bb[1]
@@ -8388,7 +8402,8 @@ general_service_handler
     lda l00b8                                                         // 51b6: a5 b8       ..  :b1b6[1]
     pha                                                               // 51b8: 48          H   :b1b8[1]
     lda l00b9                                                         // 51b9: a5 b9       ..  :b1b9[1]
-    pha                                                               // 51bb: 48          H   :b1bb[1]   // push A,Y onto the stack
+    // push A,Y onto the stack
+    pha                                                               // 51bb: 48          H   :b1bb[1]
     tya                                                               // 51bc: 98          .   :b1bc[1]
     pha                                                               // 51bd: 48          H   :b1bd[1]
     txa                                                               // 51be: 8a          .   :b1be[1]
@@ -8440,7 +8455,8 @@ cb1fc
     jsr sub_cb882                                                     // 5200: 20 82 b8     .. :b200[1]
 // $5203 referenced 10 times by $b1c6[1], $b1db[1], $b1df[1], $b219[1], $b21e[1], $b228[1], $b22c[1], $b262[1], $b26a[1], $b280[1]
 cb203
-    pla                                                               // 5203: 68          h   :b203[1]   // pull A,Y from the stack
+    // pull A,Y from the stack
+    pla                                                               // 5203: 68          h   :b203[1]
     tay                                                               // 5204: a8          .   :b204[1]
     pla                                                               // 5205: 68          h   :b205[1]
     sta l00b9                                                         // 5206: 85 b9       ..  :b206[1]
@@ -8759,7 +8775,8 @@ cb3ba
 cb3de
     lda #osbyte_read_himem                                            // 53de: a9 84       ..  :b3de[1]
     jsr osbyte                                                        // 53e0: 20 f4 ff     .. :b3e0[1]   // Read top of user memory (HIMEM)
-    tya                                                               // 53e3: 98          .   :b3e3[1]   // push Y,X onto the stack// X and Y contain the address of HIMEM (low, high)
+    // push Y,X onto the stack
+    tya                                                               // 53e3: 98          .   :b3e3[1]   // X and Y contain the address of HIMEM (low, high)
     pha                                                               // 53e4: 48          H   :b3e4[1]
     txa                                                               // 53e5: 8a          .   :b3e5[1]
     pha                                                               // 53e6: 48          H   :b3e6[1]
@@ -8987,7 +9004,8 @@ cb534
     lda l00bb                                                         // 5548: a5 bb       ..  :b548[1]
     iny                                                               // 554a: c8          .   :b54a[1]   // Y=$fc
     adc (l00b8),y                                                     // 554b: 71 b8       q.  :b54b[1]
-    pha                                                               // 554d: 48          H   :b54d[1]   // push A,X onto the stack
+    // push A,X onto the stack
+    pha                                                               // 554d: 48          H   :b54d[1]
     txa                                                               // 554e: 8a          .   :b54e[1]
     pha                                                               // 554f: 48          H   :b54f[1]
     lda #$ff                                                          // 5550: a9 ff       ..  :b550[1]
@@ -9360,7 +9378,8 @@ cb736
 // $5745 referenced 5 times by $b369[1], $b8b7[1], $b8d1[1], $bc78[1], $bc9e[1]
 sub_cb745
     sta l00bf                                                         // 5745: 85 bf       ..  :b745[1]
-    txa                                                               // 5747: 8a          .   :b747[1]   // push X,Y onto the stack
+    // push X,Y onto the stack
+    txa                                                               // 5747: 8a          .   :b747[1]
     pha                                                               // 5748: 48          H   :b748[1]
     tya                                                               // 5749: 98          .   :b749[1]
     pha                                                               // 574a: 48          H   :b74a[1]
@@ -9383,7 +9402,8 @@ loop_cb75a
     tay                                                               // 5764: a8          .   :b764[1]
     lda l00bf                                                         // 5765: a5 bf       ..  :b765[1]
     jsr sub_cb771                                                     // 5767: 20 71 b7     q. :b767[1]
-    pla                                                               // 576a: 68          h   :b76a[1]   // pull X,Y from the stack
+    // pull X,Y from the stack
+    pla                                                               // 576a: 68          h   :b76a[1]
     tay                                                               // 576b: a8          .   :b76b[1]
     pla                                                               // 576c: 68          h   :b76c[1]
     tax                                                               // 576d: aa          .   :b76d[1]
@@ -9440,7 +9460,8 @@ loop_cb7be
     lda romsel_copy                                                   // 57c6: a5 f4       ..  :b7c6[1]
     pha                                                               // 57c8: 48          H   :b7c8[1]
     lda #1                                                            // 57c9: a9 01       ..  :b7c9[1]
-    pha                                                               // 57cb: 48          H   :b7cb[1]   // push A,X onto the stack
+    // push A,X onto the stack
+    pha                                                               // 57cb: 48          H   :b7cb[1]
     txa                                                               // 57cc: 8a          .   :b7cc[1]
     pha                                                               // 57cd: 48          H   :b7cd[1]
     lda l00b0                                                         // 57ce: a5 b0       ..  :b7ce[1]
@@ -9507,7 +9528,8 @@ cb7ed
 
 // $582b referenced 16 times by $b1c1[1], $b2c8[1], $b2e7[1], $b32c[1], $b35a[1], $b3b0[1], $b3ec[1], $b429[1], $b4a3[1], $b573[1], $b5ca[1], $b5e8[1], $b604[1], $b611[1], $b86b[1], $beb5[1]
 cb82b
-    php                                                               // 582b: 08          .   :b82b[1]   // push flags,A,X onto the stack
+    // push flags,A,X onto the stack
+    php                                                               // 582b: 08          .   :b82b[1]
     pha                                                               // 582c: 48          H   :b82c[1]
     txa                                                               // 582d: 8a          .   :b82d[1]
     pha                                                               // 582e: 48          H   :b82e[1]
@@ -9516,7 +9538,8 @@ cb82b
     ldx romsel_copy                                                   // 5833: a6 f4       ..  :b833[1]
     lda l0df0,x                                                       // 5835: bd f0 0d    ... :b835[1]
     sta l00b9                                                         // 5838: 85 b9       ..  :b838[1]
-    pla                                                               // 583a: 68          h   :b83a[1]   // pull flags,A,X from the stack
+    // pull flags,A,X from the stack
+    pla                                                               // 583a: 68          h   :b83a[1]
     tax                                                               // 583b: aa          .   :b83b[1]
     pla                                                               // 583c: 68          h   :b83c[1]
     plp                                                               // 583d: 28          (   :b83d[1]
@@ -9554,13 +9577,15 @@ sub_cb850
 
 // $585d referenced 8 times by $b2f2[1], $b340[1], $b406[1], $b63f[1], $b66e[1], $b7a7[1], $be64[1], $be9d[1]
 sub_cb85d
-    pha                                                               // 585d: 48          H   :b85d[1]   // push A,Y onto the stack
+    // push A,Y onto the stack
+    pha                                                               // 585d: 48          H   :b85d[1]
     tya                                                               // 585e: 98          .   :b85e[1]
     pha                                                               // 585f: 48          H   :b85f[1]
     ldy #$ee                                                          // 5860: a0 ee       ..  :b860[1]
     lda (l00b8),y                                                     // 5862: b1 b8       ..  :b862[1]
     sta l00b8                                                         // 5864: 85 b8       ..  :b864[1]
-    pla                                                               // 5866: 68          h   :b866[1]   // pull A,Y from the stack
+    // pull A,Y from the stack
+    pla                                                               // 5866: 68          h   :b866[1]
     tay                                                               // 5867: a8          .   :b867[1]
     pla                                                               // 5868: 68          h   :b868[1]
     bit l00b8                                                         // 5869: 24 b8       $.  :b869[1]
@@ -9694,7 +9719,8 @@ lb980
 
 // $5986 referenced 3 times by $b8d4[1], $bc49[1], $bcb2[1]
 sub_cb986
-    txa                                                               // 5986: 8a          .   :b986[1]   // push X,Y onto the stack
+    // push X,Y onto the stack
+    txa                                                               // 5986: 8a          .   :b986[1]
     pha                                                               // 5987: 48          H   :b987[1]
     tya                                                               // 5988: 98          .   :b988[1]
     pha                                                               // 5989: 48          H   :b989[1]
@@ -9748,7 +9774,8 @@ loop_cb9d1
     clc                                                               // 59d1: 18          .   :b9d1[1]
 // $59d2 referenced 1 time by $b9f3[1]
 cb9d2
-    pla                                                               // 59d2: 68          h   :b9d2[1]   // pull X,Y from the stack
+    // pull X,Y from the stack
+    pla                                                               // 59d2: 68          h   :b9d2[1]
     tay                                                               // 59d3: a8          .   :b9d3[1]
     pla                                                               // 59d4: 68          h   :b9d4[1]
     tax                                                               // 59d5: aa          .   :b9d5[1]
@@ -10636,7 +10663,8 @@ loop_cbeab
     jsr cb82b                                                         // 5eb5: 20 2b b8     +. :beb5[1]
     stx l00ba                                                         // 5eb8: 86 ba       ..  :beb8[1]
     sty l00bb                                                         // 5eba: 84 bb       ..  :beba[1]
-    pla                                                               // 5ebc: 68          h   :bebc[1]   // pull A,Y from the stack
+    // pull A,Y from the stack
+    pla                                                               // 5ebc: 68          h   :bebc[1]
     tay                                                               // 5ebd: a8          .   :bebd[1]
     pla                                                               // 5ebe: 68          h   :bebe[1]
     sta (l00ba),y                                                     // 5ebf: 91 ba       ..  :bebf[1]
@@ -10654,7 +10682,8 @@ sub_cbec2
 service_handler
     cmp #service_claim_absolute_workspace                             // 5ec8: c9 01       ..  :bec8[1]
     bne cbee0                                                         // 5eca: d0 14       ..  :beca[1]
-    pha                                                               // 5ecc: 48          H   :becc[1]   // push A,Y onto the stack
+    // push A,Y onto the stack
+    pha                                                               // 5ecc: 48          H   :becc[1]
     tya                                                               // 5ecd: 98          .   :becd[1]
     pha                                                               // 5ece: 48          H   :bece[1]
     lda #osbyte_issue_service_request                                 // 5ecf: a9 8f       ..  :becf[1]

--- a/examples/known_good/lisp406_acme.asm
+++ b/examples/known_good/lisp406_acme.asm
@@ -347,7 +347,8 @@ INITSE
     rts                                            ; 813c: 60          `
 
 HELP
-    pha                                            ; 813d: 48          H              ; push A,X,Y onto the stack
+    ; push A,X,Y onto the stack
+    pha                                            ; 813d: 48          H
     txa                                            ; 813e: 8a          .
     pha                                            ; 813f: 48          H
     tya                                            ; 8140: 98          .
@@ -358,7 +359,8 @@ HELP
     jsr MESSAH                                     ; 8147: 20 fc 84     ..
     pla                                            ; 814a: 68          h
     sta HANDLE                                     ; 814b: 85 13       ..
-    pla                                            ; 814d: 68          h              ; pull A,X,Y from the stack
+    ; pull A,X,Y from the stack
+    pla                                            ; 814d: 68          h
     tay                                            ; 814e: a8          .
     pla                                            ; 814f: 68          h
     tax                                            ; 8150: aa          .
@@ -366,7 +368,8 @@ HELP
     rts                                            ; 8152: 60          `
 
 OKCALL
-    pha                                            ; 8153: 48          H              ; push A,Y,X onto the stack
+    ; push A,Y,X onto the stack
+    pha                                            ; 8153: 48          H
     tya                                            ; 8154: 98          .
     pha                                            ; 8155: 48          H
     txa                                            ; 8156: 8a          .
@@ -405,7 +408,8 @@ STLISP
     jmp osbyte                                     ; 818f: 4c f4 ff    L..            ; Start up LISP; Enter language ROM X
 
 NOTLSP
-    pla                                            ; 8192: 68          h              ; pull A,Y,X from the stack
+    ; pull A,Y,X from the stack
+    pla                                            ; 8192: 68          h
     tax                                            ; 8193: aa          .
     pla                                            ; 8194: 68          h
     tay                                            ; 8195: a8          .
@@ -4084,7 +4088,8 @@ OUTL
     pla                                            ; 97fc: 68          h
     sta WSA                                        ; 97fd: 85 34       .4             ; Save status
     lda WSA+1                                      ; 97ff: a5 35       .5             ; Restore A
-    pha                                            ; 9801: 48          H              ; push A,X,Y onto the stack
+    ; push A,X,Y onto the stack
+    pha                                            ; 9801: 48          H
     txa                                            ; 9802: 8a          .
     pha                                            ; 9803: 48          H
     tya                                            ; 9804: 98          .
@@ -4129,11 +4134,13 @@ BUILD2
     rts                                            ; 9843: 60          `
 
 SETNUM
-    pha                                            ; 9844: 48          H              ; Num atom in WSB; push A,X onto the stack
+    ; push A,X onto the stack
+    pha                                            ; 9844: 48          H              ; Num atom in WSB
     txa                                            ; 9845: 8a          .
     pha                                            ; 9846: 48          H
     jsr ALNUM                                      ; 9847: 20 3d 84     =.
-    pla                                            ; 984a: 68          h              ; pull A,X from the stack
+    ; pull A,X from the stack
+    pla                                            ; 984a: 68          h
     tax                                            ; 984b: aa          .
     pla                                            ; 984c: 68          h
     ldy #2                                         ; 984d: a0 02       ..

--- a/examples/known_good/lisp406_beebasm.asm
+++ b/examples/known_good/lisp406_beebasm.asm
@@ -347,7 +347,8 @@ oscli   = &fff7
     rts                                            ; 813c: 60          `
 
 .HELP
-    pha                                            ; 813d: 48          H              ; push A,X,Y onto the stack
+    ; push A,X,Y onto the stack
+    pha                                            ; 813d: 48          H
     txa                                            ; 813e: 8a          .
     pha                                            ; 813f: 48          H
     tya                                            ; 8140: 98          .
@@ -358,7 +359,8 @@ oscli   = &fff7
     jsr MESSAH                                     ; 8147: 20 fc 84     ..
     pla                                            ; 814a: 68          h
     sta HANDLE                                     ; 814b: 85 13       ..
-    pla                                            ; 814d: 68          h              ; pull A,X,Y from the stack
+    ; pull A,X,Y from the stack
+    pla                                            ; 814d: 68          h
     tay                                            ; 814e: a8          .
     pla                                            ; 814f: 68          h
     tax                                            ; 8150: aa          .
@@ -366,7 +368,8 @@ oscli   = &fff7
     rts                                            ; 8152: 60          `
 
 .OKCALL
-    pha                                            ; 8153: 48          H              ; push A,Y,X onto the stack
+    ; push A,Y,X onto the stack
+    pha                                            ; 8153: 48          H
     tya                                            ; 8154: 98          .
     pha                                            ; 8155: 48          H
     txa                                            ; 8156: 8a          .
@@ -405,7 +408,8 @@ oscli   = &fff7
     jmp osbyte                                     ; 818f: 4c f4 ff    L..            ; Start up LISP; Enter language ROM X
 
 .NOTLSP
-    pla                                            ; 8192: 68          h              ; pull A,Y,X from the stack
+    ; pull A,Y,X from the stack
+    pla                                            ; 8192: 68          h
     tax                                            ; 8193: aa          .
     pla                                            ; 8194: 68          h
     tay                                            ; 8195: a8          .
@@ -4084,7 +4088,8 @@ oscli   = &fff7
     pla                                            ; 97fc: 68          h
     sta WSA                                        ; 97fd: 85 34       .4             ; Save status
     lda WSA+1                                      ; 97ff: a5 35       .5             ; Restore A
-    pha                                            ; 9801: 48          H              ; push A,X,Y onto the stack
+    ; push A,X,Y onto the stack
+    pha                                            ; 9801: 48          H
     txa                                            ; 9802: 8a          .
     pha                                            ; 9803: 48          H
     tya                                            ; 9804: 98          .
@@ -4129,11 +4134,13 @@ oscli   = &fff7
     rts                                            ; 9843: 60          `
 
 .SETNUM
-    pha                                            ; 9844: 48          H              ; Num atom in WSB; push A,X onto the stack
+    ; push A,X onto the stack
+    pha                                            ; 9844: 48          H              ; Num atom in WSB
     txa                                            ; 9845: 8a          .
     pha                                            ; 9846: 48          H
     jsr ALNUM                                      ; 9847: 20 3d 84     =.
-    pla                                            ; 984a: 68          h              ; pull A,X from the stack
+    ; pull A,X from the stack
+    pla                                            ; 984a: 68          h
     tax                                            ; 984b: aa          .
     pla                                            ; 984c: 68          h
     ldy #2                                         ; 984d: a0 02       ..

--- a/examples/known_good/os12_acme.asm
+++ b/examples/known_good/os12_acme.asm
@@ -3278,7 +3278,8 @@ ccfee
     ora l00d2                                                         ; cff9: 05 d2       ..
     eor l00d3                                                         ; cffb: 45 d3       E.
     sta (l00d8),y                                                     ; cffd: 91 d8       ..
-    tya                                                               ; cfff: 98          .              ; add 8 to Y
+    ; add 8 to Y
+    tya                                                               ; cfff: 98          .
     clc                                                               ; d000: 18          .
     adc #8                                                            ; d001: 69 08       i.
     tay                                                               ; d003: a8          .
@@ -5298,7 +5299,8 @@ return_24
 
     cld                                                               ; dc93: d8          .
     lda l00fc                                                         ; dc94: a5 fc       ..
-    pha                                                               ; dc96: 48          H              ; push A,X,Y onto the stack
+    ; push A,X,Y onto the stack
+    pha                                                               ; dc96: 48          H
     txa                                                               ; dc97: 8a          .
     pha                                                               ; dc98: 48          H
     tya                                                               ; dc99: 98          .
@@ -5376,7 +5378,8 @@ cdcf3
     beq return_25                                                     ; dcf8: f0 e3       ..
     pla                                                               ; dcfa: 68          h
     pla                                                               ; dcfb: 68          h
-    pla                                                               ; dcfc: 68          h              ; pull A,X,Y from the stack
+    ; pull A,X,Y from the stack
+    pla                                                               ; dcfc: 68          h
     tay                                                               ; dcfd: a8          .
     pla                                                               ; dcfe: 68          h
     tax                                                               ; dcff: aa          .
@@ -5624,7 +5627,8 @@ cde72
 cde7f
     jmp cdcf3                                                         ; de7f: 4c f3 dc    L..
 
-    pla                                                               ; de82: 68          h              ; pull A,X,Y from the stack
+    ; pull A,X,Y from the stack
+    pla                                                               ; de82: 68          h
     tay                                                               ; de83: a8          .
     pla                                                               ; de84: 68          h
     tax                                                               ; de85: aa          .
@@ -5684,7 +5688,8 @@ cdec5
 ; $dec7 referenced 1 time by $dec3
 cdec7
     sta l00e6                                                         ; dec7: 85 e6       ..
-    txa                                                               ; dec9: 8a          .              ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; dec9: 8a          .
     pha                                                               ; deca: 48          H
     tya                                                               ; decb: 98          .
     pha                                                               ; decc: 48          H
@@ -5723,7 +5728,8 @@ cdf03
     sta l00e6                                                         ; df03: 85 e6       ..
 ; $df05 referenced 1 time by $defe
 cdf05
-    pla                                                               ; df05: 68          h              ; pull X,Y from the stack
+    ; pull X,Y from the stack
+    pla                                                               ; df05: 68          h
     tay                                                               ; df06: a8          .
     pla                                                               ; df07: 68          h
     tax                                                               ; df08: aa          .
@@ -5939,7 +5945,8 @@ sub_ce03a
 
 ; $e0a4 referenced 1 time by $ffcb
 ce0a4
-    pha                                                               ; e0a4: 48          H              ; push A,X,Y onto the stack
+    ; push A,X,Y onto the stack
+    pha                                                               ; e0a4: 48          H
     txa                                                               ; e0a5: 8a          .
     pha                                                               ; e0a6: 48          H
     tya                                                               ; e0a7: 98          .
@@ -6012,7 +6019,8 @@ ce0f7
 ; $e10d referenced 3 times by $e0b9, $e0fc, $e101
 ce10d
     pla                                                               ; e10d: 68          h
-    pla                                                               ; e10e: 68          h              ; pull A,X,Y from the stack
+    ; pull A,X,Y from the stack
+    pla                                                               ; e10e: 68          h
     tay                                                               ; e10f: a8          .
     pla                                                               ; e110: 68          h
     tax                                                               ; e111: aa          .
@@ -9122,7 +9130,8 @@ cf3c3
     bpl cf370                                                         ; f3c8: 10 a6       ..             ; ALWAYS branch
 
     sta l00bc                                                         ; f3ca: 85 bc       ..
-    txa                                                               ; f3cc: 8a          .              ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; f3cc: 8a          .
     pha                                                               ; f3cd: 48          H
     tya                                                               ; f3ce: 98          .
     pha                                                               ; f3cf: 48          H
@@ -9228,7 +9237,8 @@ cf46f
     sta l00bc                                                         ; f46f: 85 bc       ..
 ; $f471 referenced 2 times by $f3ef, $f520
 cf471
-    pla                                                               ; f471: 68          h              ; pull X,Y from the stack
+    ; pull X,Y from the stack
+    pla                                                               ; f471: 68          h
     tay                                                               ; f472: a8          .
     pla                                                               ; f473: 68          h
     tax                                                               ; f474: aa          .
@@ -9282,7 +9292,8 @@ loop_cf49b
 return_49
     rts                                                               ; f4c8: 60          `
 
-    txa                                                               ; f4c9: 8a          .              ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; f4c9: 8a          .
     pha                                                               ; f4ca: 48          H
     tya                                                               ; f4cb: 98          .
     pha                                                               ; f4cc: 48          H
@@ -9346,7 +9357,8 @@ cf523
     !byte 0                                                           ; f528: 00          .
 
     sta l00c4                                                         ; f529: 85 c4       ..
-    txa                                                               ; f52b: 8a          .              ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; f52b: 8a          .
     pha                                                               ; f52c: 48          H
     tya                                                               ; f52d: 98          .
     pha                                                               ; f52e: 48          H
@@ -9486,7 +9498,8 @@ cf61b
 return_50
     rts                                                               ; f61d: 60          `
 
-    pha                                                               ; f61e: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; f61e: 48          H
     tya                                                               ; f61f: 98          .
     pha                                                               ; f620: 48          H
     txa                                                               ; f621: 8a          .
@@ -9496,7 +9509,8 @@ return_50
     lda l00e2                                                         ; f628: a5 e2       ..
     and #$40 ; '@'                                                    ; f62a: 29 40       )@
     tax                                                               ; f62c: aa          .
-    pla                                                               ; f62d: 68          h              ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; f62d: 68          h
     tay                                                               ; f62e: a8          .
     pla                                                               ; f62f: 68          h
     rts                                                               ; f630: 60          `
@@ -9707,7 +9721,8 @@ cf790
 sub_cf797
     lda l0247                                                         ; f797: ad 47 02    .G.
     beq cf7ad                                                         ; f79a: f0 11       ..
-    txa                                                               ; f79c: 8a          .              ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; f79c: 8a          .
     pha                                                               ; f79d: 48          H
     tya                                                               ; f79e: 98          .
     pha                                                               ; f79f: 48          H
@@ -9715,7 +9730,8 @@ sub_cf797
     sta l00bd                                                         ; f7a3: 85 bd       ..
     lda #$ff                                                          ; f7a5: a9 ff       ..
     sta l00c0                                                         ; f7a7: 85 c0       ..
-    pla                                                               ; f7a9: 68          h              ; pull X,Y from the stack
+    ; pull X,Y from the stack
+    pla                                                               ; f7a9: 68          h
     tay                                                               ; f7aa: a8          .
     pla                                                               ; f7ab: 68          h
     tax                                                               ; f7ac: aa          .
@@ -10113,13 +10129,15 @@ cf9f1
     lda #$fa                                                          ; f9f3: a9 fa       ..
 ; $f9f5 referenced 2 times by $f9d7, $f9e1
 cf9f5
-    pha                                                               ; f9f5: 48          H              ; push A,Y,X onto the stack
+    ; push A,Y,X onto the stack
+    pha                                                               ; f9f5: 48          H
     tya                                                               ; f9f6: 98          .
     pha                                                               ; f9f7: 48          H
     txa                                                               ; f9f8: 8a          .
     pha                                                               ; f9f9: 48          H
     jsr cf8b6                                                         ; f9fa: 20 b6 f8     ..
-    pla                                                               ; f9fd: 68          h              ; pull A,Y,X from the stack
+    ; pull A,Y,X from the stack
+    pla                                                               ; f9fd: 68          h
     tax                                                               ; f9fe: aa          .
     pla                                                               ; f9ff: 68          h
     tay                                                               ; fa00: a8          .
@@ -10170,7 +10188,8 @@ cfa3c
     adc #1                                                            ; fa41: 69 01       i.
 ; $fa43 referenced 1 time by $fa3e
 cfa43
-    pha                                                               ; fa43: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; fa43: 48          H
     tya                                                               ; fa44: 98          .
     pha                                                               ; fa45: 48          H
 ; $fa46 referenced 4 times by $f24e, $f641, $f947, $f9b7
@@ -10555,7 +10574,8 @@ return_59
     pha                                                               ; ff53: 48          H
     pha                                                               ; ff54: 48          H
     pha                                                               ; ff55: 48          H
-    php                                                               ; ff56: 08          .              ; push flags,A,X,Y onto the stack
+    ; push flags,A,X,Y onto the stack
+    php                                                               ; ff56: 08          .
     pha                                                               ; ff57: 48          H
     txa                                                               ; ff58: 8a          .
     pha                                                               ; ff59: 48          H
@@ -10576,14 +10596,16 @@ return_59
     lda l0d9f,y                                                       ; ff7b: b9 9f 0d    ...
     sta romsel_copy                                                   ; ff7e: 85 f4       ..
     sta romsel                                                        ; ff80: 8d 30 fe    .0.
-    pla                                                               ; ff83: 68          h              ; pull A,X,Y from the stack
+    ; pull A,X,Y from the stack
+    pla                                                               ; ff83: 68          h
     tay                                                               ; ff84: a8          .
     pla                                                               ; ff85: 68          h
     tax                                                               ; ff86: aa          .
     pla                                                               ; ff87: 68          h
     rti                                                               ; ff88: 40          @
 
-    php                                                               ; ff89: 08          .              ; push flags,A,X onto the stack
+    ; push flags,A,X onto the stack
+    php                                                               ; ff89: 08          .
     pha                                                               ; ff8a: 48          H
     txa                                                               ; ff8b: 8a          .
     pha                                                               ; ff8c: 48          H
@@ -10592,7 +10614,8 @@ return_59
     sta l0105,x                                                       ; ff91: 9d 05 01    ...
     lda l0103,x                                                       ; ff94: bd 03 01    ...
     sta l0106,x                                                       ; ff97: 9d 06 01    ...
-    pla                                                               ; ff9a: 68          h              ; pull A,X from the stack
+    ; pull A,X from the stack
+    pla                                                               ; ff9a: 68          h
     tax                                                               ; ff9b: aa          .
     pla                                                               ; ff9c: 68          h
     pla                                                               ; ff9d: 68          h

--- a/examples/known_good/os12_beebasm.asm
+++ b/examples/known_good/os12_beebasm.asm
@@ -3278,7 +3278,8 @@ tube_data_register_3                    = &fee5
     ora l00d2                                                         ; cff9: 05 d2       ..
     eor l00d3                                                         ; cffb: 45 d3       E.
     sta (l00d8),y                                                     ; cffd: 91 d8       ..
-    tya                                                               ; cfff: 98          .              ; add 8 to Y
+    ; add 8 to Y
+    tya                                                               ; cfff: 98          .
     clc                                                               ; d000: 18          .
     adc #8                                                            ; d001: 69 08       i.
     tay                                                               ; d003: a8          .
@@ -5298,7 +5299,8 @@ tube_data_register_3                    = &fee5
 
     cld                                                               ; dc93: d8          .
     lda l00fc                                                         ; dc94: a5 fc       ..
-    pha                                                               ; dc96: 48          H              ; push A,X,Y onto the stack
+    ; push A,X,Y onto the stack
+    pha                                                               ; dc96: 48          H
     txa                                                               ; dc97: 8a          .
     pha                                                               ; dc98: 48          H
     tya                                                               ; dc99: 98          .
@@ -5376,7 +5378,8 @@ tube_data_register_3                    = &fee5
     beq return_25                                                     ; dcf8: f0 e3       ..
     pla                                                               ; dcfa: 68          h
     pla                                                               ; dcfb: 68          h
-    pla                                                               ; dcfc: 68          h              ; pull A,X,Y from the stack
+    ; pull A,X,Y from the stack
+    pla                                                               ; dcfc: 68          h
     tay                                                               ; dcfd: a8          .
     pla                                                               ; dcfe: 68          h
     tax                                                               ; dcff: aa          .
@@ -5624,7 +5627,8 @@ tube_data_register_3                    = &fee5
 .cde7f
     jmp cdcf3                                                         ; de7f: 4c f3 dc    L..
 
-    pla                                                               ; de82: 68          h              ; pull A,X,Y from the stack
+    ; pull A,X,Y from the stack
+    pla                                                               ; de82: 68          h
     tay                                                               ; de83: a8          .
     pla                                                               ; de84: 68          h
     tax                                                               ; de85: aa          .
@@ -5684,7 +5688,8 @@ tube_data_register_3                    = &fee5
 ; &dec7 referenced 1 time by &dec3
 .cdec7
     sta l00e6                                                         ; dec7: 85 e6       ..
-    txa                                                               ; dec9: 8a          .              ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; dec9: 8a          .
     pha                                                               ; deca: 48          H
     tya                                                               ; decb: 98          .
     pha                                                               ; decc: 48          H
@@ -5723,7 +5728,8 @@ tube_data_register_3                    = &fee5
     sta l00e6                                                         ; df03: 85 e6       ..
 ; &df05 referenced 1 time by &defe
 .cdf05
-    pla                                                               ; df05: 68          h              ; pull X,Y from the stack
+    ; pull X,Y from the stack
+    pla                                                               ; df05: 68          h
     tay                                                               ; df06: a8          .
     pla                                                               ; df07: 68          h
     tax                                                               ; df08: aa          .
@@ -5939,7 +5945,8 @@ tube_data_register_3                    = &fee5
 
 ; &e0a4 referenced 1 time by &ffcb
 .ce0a4
-    pha                                                               ; e0a4: 48          H              ; push A,X,Y onto the stack
+    ; push A,X,Y onto the stack
+    pha                                                               ; e0a4: 48          H
     txa                                                               ; e0a5: 8a          .
     pha                                                               ; e0a6: 48          H
     tya                                                               ; e0a7: 98          .
@@ -6012,7 +6019,8 @@ tube_data_register_3                    = &fee5
 ; &e10d referenced 3 times by &e0b9, &e0fc, &e101
 .ce10d
     pla                                                               ; e10d: 68          h
-    pla                                                               ; e10e: 68          h              ; pull A,X,Y from the stack
+    ; pull A,X,Y from the stack
+    pla                                                               ; e10e: 68          h
     tay                                                               ; e10f: a8          .
     pla                                                               ; e110: 68          h
     tax                                                               ; e111: aa          .
@@ -9122,7 +9130,8 @@ le5b4 = le5b3+1
     bpl cf370                                                         ; f3c8: 10 a6       ..             ; ALWAYS branch
 
     sta l00bc                                                         ; f3ca: 85 bc       ..
-    txa                                                               ; f3cc: 8a          .              ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; f3cc: 8a          .
     pha                                                               ; f3cd: 48          H
     tya                                                               ; f3ce: 98          .
     pha                                                               ; f3cf: 48          H
@@ -9228,7 +9237,8 @@ le5b4 = le5b3+1
     sta l00bc                                                         ; f46f: 85 bc       ..
 ; &f471 referenced 2 times by &f3ef, &f520
 .cf471
-    pla                                                               ; f471: 68          h              ; pull X,Y from the stack
+    ; pull X,Y from the stack
+    pla                                                               ; f471: 68          h
     tay                                                               ; f472: a8          .
     pla                                                               ; f473: 68          h
     tax                                                               ; f474: aa          .
@@ -9282,7 +9292,8 @@ le5b4 = le5b3+1
 .return_49
     rts                                                               ; f4c8: 60          `
 
-    txa                                                               ; f4c9: 8a          .              ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; f4c9: 8a          .
     pha                                                               ; f4ca: 48          H
     tya                                                               ; f4cb: 98          .
     pha                                                               ; f4cc: 48          H
@@ -9346,7 +9357,8 @@ le5b4 = le5b3+1
     equb 0                                                            ; f528: 00          .
 
     sta l00c4                                                         ; f529: 85 c4       ..
-    txa                                                               ; f52b: 8a          .              ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; f52b: 8a          .
     pha                                                               ; f52c: 48          H
     tya                                                               ; f52d: 98          .
     pha                                                               ; f52e: 48          H
@@ -9486,7 +9498,8 @@ le5b4 = le5b3+1
 .return_50
     rts                                                               ; f61d: 60          `
 
-    pha                                                               ; f61e: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; f61e: 48          H
     tya                                                               ; f61f: 98          .
     pha                                                               ; f620: 48          H
     txa                                                               ; f621: 8a          .
@@ -9496,7 +9509,8 @@ le5b4 = le5b3+1
     lda l00e2                                                         ; f628: a5 e2       ..
     and #&40 ; '@'                                                    ; f62a: 29 40       )@
     tax                                                               ; f62c: aa          .
-    pla                                                               ; f62d: 68          h              ; pull A,Y from the stack
+    ; pull A,Y from the stack
+    pla                                                               ; f62d: 68          h
     tay                                                               ; f62e: a8          .
     pla                                                               ; f62f: 68          h
     rts                                                               ; f630: 60          `
@@ -9707,7 +9721,8 @@ le5b4 = le5b3+1
 .sub_cf797
     lda l0247                                                         ; f797: ad 47 02    .G.
     beq cf7ad                                                         ; f79a: f0 11       ..
-    txa                                                               ; f79c: 8a          .              ; push X,Y onto the stack
+    ; push X,Y onto the stack
+    txa                                                               ; f79c: 8a          .
     pha                                                               ; f79d: 48          H
     tya                                                               ; f79e: 98          .
     pha                                                               ; f79f: 48          H
@@ -9715,7 +9730,8 @@ le5b4 = le5b3+1
     sta l00bd                                                         ; f7a3: 85 bd       ..
     lda #&ff                                                          ; f7a5: a9 ff       ..
     sta l00c0                                                         ; f7a7: 85 c0       ..
-    pla                                                               ; f7a9: 68          h              ; pull X,Y from the stack
+    ; pull X,Y from the stack
+    pla                                                               ; f7a9: 68          h
     tay                                                               ; f7aa: a8          .
     pla                                                               ; f7ab: 68          h
     tax                                                               ; f7ac: aa          .
@@ -10113,13 +10129,15 @@ le5b4 = le5b3+1
     lda #&fa                                                          ; f9f3: a9 fa       ..
 ; &f9f5 referenced 2 times by &f9d7, &f9e1
 .cf9f5
-    pha                                                               ; f9f5: 48          H              ; push A,Y,X onto the stack
+    ; push A,Y,X onto the stack
+    pha                                                               ; f9f5: 48          H
     tya                                                               ; f9f6: 98          .
     pha                                                               ; f9f7: 48          H
     txa                                                               ; f9f8: 8a          .
     pha                                                               ; f9f9: 48          H
     jsr cf8b6                                                         ; f9fa: 20 b6 f8     ..
-    pla                                                               ; f9fd: 68          h              ; pull A,Y,X from the stack
+    ; pull A,Y,X from the stack
+    pla                                                               ; f9fd: 68          h
     tax                                                               ; f9fe: aa          .
     pla                                                               ; f9ff: 68          h
     tay                                                               ; fa00: a8          .
@@ -10170,7 +10188,8 @@ le5b4 = le5b3+1
     adc #1                                                            ; fa41: 69 01       i.
 ; &fa43 referenced 1 time by &fa3e
 .cfa43
-    pha                                                               ; fa43: 48          H              ; push A,Y onto the stack
+    ; push A,Y onto the stack
+    pha                                                               ; fa43: 48          H
     tya                                                               ; fa44: 98          .
     pha                                                               ; fa45: 48          H
 ; &fa46 referenced 4 times by &f24e, &f641, &f947, &f9b7
@@ -10555,7 +10574,8 @@ le5b4 = le5b3+1
     pha                                                               ; ff53: 48          H
     pha                                                               ; ff54: 48          H
     pha                                                               ; ff55: 48          H
-    php                                                               ; ff56: 08          .              ; push flags,A,X,Y onto the stack
+    ; push flags,A,X,Y onto the stack
+    php                                                               ; ff56: 08          .
     pha                                                               ; ff57: 48          H
     txa                                                               ; ff58: 8a          .
     pha                                                               ; ff59: 48          H
@@ -10576,14 +10596,16 @@ le5b4 = le5b3+1
     lda l0d9f,y                                                       ; ff7b: b9 9f 0d    ...
     sta romsel_copy                                                   ; ff7e: 85 f4       ..
     sta romsel                                                        ; ff80: 8d 30 fe    .0.
-    pla                                                               ; ff83: 68          h              ; pull A,X,Y from the stack
+    ; pull A,X,Y from the stack
+    pla                                                               ; ff83: 68          h
     tay                                                               ; ff84: a8          .
     pla                                                               ; ff85: 68          h
     tax                                                               ; ff86: aa          .
     pla                                                               ; ff87: 68          h
     rti                                                               ; ff88: 40          @
 
-    php                                                               ; ff89: 08          .              ; push flags,A,X onto the stack
+    ; push flags,A,X onto the stack
+    php                                                               ; ff89: 08          .
     pha                                                               ; ff8a: 48          H
     txa                                                               ; ff8b: 8a          .
     pha                                                               ; ff8c: 48          H
@@ -10592,7 +10614,8 @@ le5b4 = le5b3+1
     sta l0105,x                                                       ; ff91: 9d 05 01    ...
     lda l0103,x                                                       ; ff94: bd 03 01    ...
     sta l0106,x                                                       ; ff97: 9d 06 01    ...
-    pla                                                               ; ff9a: 68          h              ; pull A,X from the stack
+    ; pull A,X from the stack
+    pla                                                               ; ff9a: 68          h
     tax                                                               ; ff9b: aa          .
     pla                                                               ; ff9c: 68          h
     pla                                                               ; ff9d: 68          h

--- a/examples/known_good/os12_xa.asm
+++ b/examples/known_good/os12_xa.asm
@@ -3278,7 +3278,8 @@ ccfee
     ora l00d2                                                         // cff9: 05 d2       ..
     eor l00d3                                                         // cffb: 45 d3       E.
     sta (l00d8),y                                                     // cffd: 91 d8       ..
-    tya                                                               // cfff: 98          .              // add 8 to Y
+    // add 8 to Y
+    tya                                                               // cfff: 98          .
     clc                                                               // d000: 18          .
     adc #8                                                            // d001: 69 08       i.
     tay                                                               // d003: a8          .
@@ -5298,7 +5299,8 @@ return_24
 
     cld                                                               // dc93: d8          .
     lda l00fc                                                         // dc94: a5 fc       ..
-    pha                                                               // dc96: 48          H              // push A,X,Y onto the stack
+    // push A,X,Y onto the stack
+    pha                                                               // dc96: 48          H
     txa                                                               // dc97: 8a          .
     pha                                                               // dc98: 48          H
     tya                                                               // dc99: 98          .
@@ -5376,7 +5378,8 @@ cdcf3
     beq return_25                                                     // dcf8: f0 e3       ..
     pla                                                               // dcfa: 68          h
     pla                                                               // dcfb: 68          h
-    pla                                                               // dcfc: 68          h              // pull A,X,Y from the stack
+    // pull A,X,Y from the stack
+    pla                                                               // dcfc: 68          h
     tay                                                               // dcfd: a8          .
     pla                                                               // dcfe: 68          h
     tax                                                               // dcff: aa          .
@@ -5624,7 +5627,8 @@ cde72
 cde7f
     jmp cdcf3                                                         // de7f: 4c f3 dc    L..
 
-    pla                                                               // de82: 68          h              // pull A,X,Y from the stack
+    // pull A,X,Y from the stack
+    pla                                                               // de82: 68          h
     tay                                                               // de83: a8          .
     pla                                                               // de84: 68          h
     tax                                                               // de85: aa          .
@@ -5684,7 +5688,8 @@ cdec5
 // $dec7 referenced 1 time by $dec3
 cdec7
     sta l00e6                                                         // dec7: 85 e6       ..
-    txa                                                               // dec9: 8a          .              // push X,Y onto the stack
+    // push X,Y onto the stack
+    txa                                                               // dec9: 8a          .
     pha                                                               // deca: 48          H
     tya                                                               // decb: 98          .
     pha                                                               // decc: 48          H
@@ -5723,7 +5728,8 @@ cdf03
     sta l00e6                                                         // df03: 85 e6       ..
 // $df05 referenced 1 time by $defe
 cdf05
-    pla                                                               // df05: 68          h              // pull X,Y from the stack
+    // pull X,Y from the stack
+    pla                                                               // df05: 68          h
     tay                                                               // df06: a8          .
     pla                                                               // df07: 68          h
     tax                                                               // df08: aa          .
@@ -5939,7 +5945,8 @@ sub_ce03a
 
 // $e0a4 referenced 1 time by $ffcb
 ce0a4
-    pha                                                               // e0a4: 48          H              // push A,X,Y onto the stack
+    // push A,X,Y onto the stack
+    pha                                                               // e0a4: 48          H
     txa                                                               // e0a5: 8a          .
     pha                                                               // e0a6: 48          H
     tya                                                               // e0a7: 98          .
@@ -6012,7 +6019,8 @@ ce0f7
 // $e10d referenced 3 times by $e0b9, $e0fc, $e101
 ce10d
     pla                                                               // e10d: 68          h
-    pla                                                               // e10e: 68          h              // pull A,X,Y from the stack
+    // pull A,X,Y from the stack
+    pla                                                               // e10e: 68          h
     tay                                                               // e10f: a8          .
     pla                                                               // e110: 68          h
     tax                                                               // e111: aa          .
@@ -9122,7 +9130,8 @@ cf3c3
     bpl cf370                                                         // f3c8: 10 a6       ..             // ALWAYS branch
 
     sta l00bc                                                         // f3ca: 85 bc       ..
-    txa                                                               // f3cc: 8a          .              // push X,Y onto the stack
+    // push X,Y onto the stack
+    txa                                                               // f3cc: 8a          .
     pha                                                               // f3cd: 48          H
     tya                                                               // f3ce: 98          .
     pha                                                               // f3cf: 48          H
@@ -9228,7 +9237,8 @@ cf46f
     sta l00bc                                                         // f46f: 85 bc       ..
 // $f471 referenced 2 times by $f3ef, $f520
 cf471
-    pla                                                               // f471: 68          h              // pull X,Y from the stack
+    // pull X,Y from the stack
+    pla                                                               // f471: 68          h
     tay                                                               // f472: a8          .
     pla                                                               // f473: 68          h
     tax                                                               // f474: aa          .
@@ -9282,7 +9292,8 @@ loop_cf49b
 return_49
     rts                                                               // f4c8: 60          `
 
-    txa                                                               // f4c9: 8a          .              // push X,Y onto the stack
+    // push X,Y onto the stack
+    txa                                                               // f4c9: 8a          .
     pha                                                               // f4ca: 48          H
     tya                                                               // f4cb: 98          .
     pha                                                               // f4cc: 48          H
@@ -9346,7 +9357,8 @@ cf523
     .byt 0                                                            // f528: 00          .
 
     sta l00c4                                                         // f529: 85 c4       ..
-    txa                                                               // f52b: 8a          .              // push X,Y onto the stack
+    // push X,Y onto the stack
+    txa                                                               // f52b: 8a          .
     pha                                                               // f52c: 48          H
     tya                                                               // f52d: 98          .
     pha                                                               // f52e: 48          H
@@ -9486,7 +9498,8 @@ cf61b
 return_50
     rts                                                               // f61d: 60          `
 
-    pha                                                               // f61e: 48          H              // push A,Y onto the stack
+    // push A,Y onto the stack
+    pha                                                               // f61e: 48          H
     tya                                                               // f61f: 98          .
     pha                                                               // f620: 48          H
     txa                                                               // f621: 8a          .
@@ -9496,7 +9509,8 @@ return_50
     lda l00e2                                                         // f628: a5 e2       ..
     and #$40 // '@'                                                   // f62a: 29 40       )@
     tax                                                               // f62c: aa          .
-    pla                                                               // f62d: 68          h              // pull A,Y from the stack
+    // pull A,Y from the stack
+    pla                                                               // f62d: 68          h
     tay                                                               // f62e: a8          .
     pla                                                               // f62f: 68          h
     rts                                                               // f630: 60          `
@@ -9707,7 +9721,8 @@ cf790
 sub_cf797
     lda l0247                                                         // f797: ad 47 02    .G.
     beq cf7ad                                                         // f79a: f0 11       ..
-    txa                                                               // f79c: 8a          .              // push X,Y onto the stack
+    // push X,Y onto the stack
+    txa                                                               // f79c: 8a          .
     pha                                                               // f79d: 48          H
     tya                                                               // f79e: 98          .
     pha                                                               // f79f: 48          H
@@ -9715,7 +9730,8 @@ sub_cf797
     sta l00bd                                                         // f7a3: 85 bd       ..
     lda #$ff                                                          // f7a5: a9 ff       ..
     sta l00c0                                                         // f7a7: 85 c0       ..
-    pla                                                               // f7a9: 68          h              // pull X,Y from the stack
+    // pull X,Y from the stack
+    pla                                                               // f7a9: 68          h
     tay                                                               // f7aa: a8          .
     pla                                                               // f7ab: 68          h
     tax                                                               // f7ac: aa          .
@@ -10113,13 +10129,15 @@ cf9f1
     lda #$fa                                                          // f9f3: a9 fa       ..
 // $f9f5 referenced 2 times by $f9d7, $f9e1
 cf9f5
-    pha                                                               // f9f5: 48          H              // push A,Y,X onto the stack
+    // push A,Y,X onto the stack
+    pha                                                               // f9f5: 48          H
     tya                                                               // f9f6: 98          .
     pha                                                               // f9f7: 48          H
     txa                                                               // f9f8: 8a          .
     pha                                                               // f9f9: 48          H
     jsr cf8b6                                                         // f9fa: 20 b6 f8     ..
-    pla                                                               // f9fd: 68          h              // pull A,Y,X from the stack
+    // pull A,Y,X from the stack
+    pla                                                               // f9fd: 68          h
     tax                                                               // f9fe: aa          .
     pla                                                               // f9ff: 68          h
     tay                                                               // fa00: a8          .
@@ -10170,7 +10188,8 @@ cfa3c
     adc #1                                                            // fa41: 69 01       i.
 // $fa43 referenced 1 time by $fa3e
 cfa43
-    pha                                                               // fa43: 48          H              // push A,Y onto the stack
+    // push A,Y onto the stack
+    pha                                                               // fa43: 48          H
     tya                                                               // fa44: 98          .
     pha                                                               // fa45: 48          H
 // $fa46 referenced 4 times by $f24e, $f641, $f947, $f9b7
@@ -10555,7 +10574,8 @@ return_59
     pha                                                               // ff53: 48          H
     pha                                                               // ff54: 48          H
     pha                                                               // ff55: 48          H
-    php                                                               // ff56: 08          .              // push flags,A,X,Y onto the stack
+    // push flags,A,X,Y onto the stack
+    php                                                               // ff56: 08          .
     pha                                                               // ff57: 48          H
     txa                                                               // ff58: 8a          .
     pha                                                               // ff59: 48          H
@@ -10576,14 +10596,16 @@ return_59
     lda l0d9f,y                                                       // ff7b: b9 9f 0d    ...
     sta romsel_copy                                                   // ff7e: 85 f4       ..
     sta romsel                                                        // ff80: 8d 30 fe    .0.
-    pla                                                               // ff83: 68          h              // pull A,X,Y from the stack
+    // pull A,X,Y from the stack
+    pla                                                               // ff83: 68          h
     tay                                                               // ff84: a8          .
     pla                                                               // ff85: 68          h
     tax                                                               // ff86: aa          .
     pla                                                               // ff87: 68          h
     rti                                                               // ff88: 40          @
 
-    php                                                               // ff89: 08          .              // push flags,A,X onto the stack
+    // push flags,A,X onto the stack
+    php                                                               // ff89: 08          .
     pha                                                               // ff8a: 48          H
     txa                                                               // ff8b: 8a          .
     pha                                                               // ff8c: 48          H
@@ -10592,7 +10614,8 @@ return_59
     sta l0105,x                                                       // ff91: 9d 05 01    ...
     lda l0103,x                                                       // ff94: bd 03 01    ...
     sta l0106,x                                                       // ff97: 9d 06 01    ...
-    pla                                                               // ff9a: 68          h              // pull A,X from the stack
+    // pull A,X from the stack
+    pla                                                               // ff9a: 68          h
     tax                                                               // ff9b: aa          .
     pla                                                               // ff9c: 68          h
     pla                                                               // ff9d: 68          h

--- a/examples/known_good/planb_acme.asm
+++ b/examples/known_good/planb_acme.asm
@@ -9806,7 +9806,8 @@ decrement_loop_counter
     dec temp_loop_counter                                             ; 3bc8: c6 21       .!
     beq return_1                                                      ; 3bca: f0 07       ..
 next_enemy
-    tya                                                               ; 3bcc: 98          .              ; add 6 to Y
+    ; add 6 to Y
+    tya                                                               ; 3bcc: 98          .
     clc                                                               ; 3bcd: 18          .
     adc #6                                                            ; 3bce: 69 06       i.
     tay                                                               ; 3bd0: a8          .
@@ -10084,7 +10085,8 @@ update_enemies
 update_enemies_loop
     lda enemies_state,y                                               ; 3d95: b9 00 0c    ...
     beq update_enemy                                                  ; 3d98: f0 07       ..
-    tya                                                               ; 3d9a: 98          .              ; add 6 to Y
+    ; add 6 to Y
+    tya                                                               ; 3d9a: 98          .
     clc                                                               ; 3d9b: 18          .
     adc #6                                                            ; 3d9c: 69 06       i.
     tay                                                               ; 3d9e: a8          .
@@ -10702,7 +10704,8 @@ skip_reset_bits
     adc #5                                                            ; 41d4: 69 05       i.
     bit current_room_door_info                                        ; 41d6: 24 15       $.
     bvc got_door_coordinates                                          ; 41d8: 50 07       P.             ; if door is horizontal then branch
-    tya                                                               ; 41da: 98          .              ; add 5 to Y
+    ; add 5 to Y
+    tya                                                               ; 41da: 98          .
     clc                                                               ; 41db: 18          .
     adc #5                                                            ; 41dc: 69 05       i.
     tay                                                               ; 41de: a8          .
@@ -11618,7 +11621,8 @@ check_for_collision_horizontal_loop
     bne check_for_collision_horizontal_loop                           ; 4740: d0 f6       ..
     dec sprite_cell_height                                            ; 4742: c6 03       ..
     beq finished_collision_check                                      ; 4744: f0 07       ..
-    tya                                                               ; 4746: 98          .              ; add 37 to Y
+    ; add 37 to Y
+    tya                                                               ; 4746: 98          .
     clc                                                               ; 4747: 18          .
     adc #$25                                                          ; 4748: 69 25       i%
     tay                                                               ; 474a: a8          .
@@ -12186,7 +12190,8 @@ check_enemies_state_loop
     jmp check_play_sound_a                                            ; 4af0: 4c 65 40    Le@
 
 check_next_enemy_state
-    tya                                                               ; 4af3: 98          .              ; add 6 to Y
+    ; add 6 to Y
+    tya                                                               ; 4af3: 98          .
     clc                                                               ; 4af4: 18          .
     adc #6                                                            ; 4af5: 69 06       i.
     tay                                                               ; 4af7: a8          .

--- a/examples/known_good/planb_beebasm.asm
+++ b/examples/known_good/planb_beebasm.asm
@@ -9806,7 +9806,8 @@ osbyte                          = &fff4
     dec temp_loop_counter                                             ; 3bc8: c6 21       .!
     beq return_1                                                      ; 3bca: f0 07       ..
 .next_enemy
-    tya                                                               ; 3bcc: 98          .              ; add 6 to Y
+    ; add 6 to Y
+    tya                                                               ; 3bcc: 98          .
     clc                                                               ; 3bcd: 18          .
     adc #6                                                            ; 3bce: 69 06       i.
     tay                                                               ; 3bd0: a8          .
@@ -10084,7 +10085,8 @@ osbyte                          = &fff4
 .update_enemies_loop
     lda enemies_state,y                                               ; 3d95: b9 00 0c    ...
     beq update_enemy                                                  ; 3d98: f0 07       ..
-    tya                                                               ; 3d9a: 98          .              ; add 6 to Y
+    ; add 6 to Y
+    tya                                                               ; 3d9a: 98          .
     clc                                                               ; 3d9b: 18          .
     adc #6                                                            ; 3d9c: 69 06       i.
     tay                                                               ; 3d9e: a8          .
@@ -10702,7 +10704,8 @@ routine_addr_high = opcode1+2
     adc #5                                                            ; 41d4: 69 05       i.
     bit current_room_door_info                                        ; 41d6: 24 15       $.
     bvc got_door_coordinates                                          ; 41d8: 50 07       P.             ; if door is horizontal then branch
-    tya                                                               ; 41da: 98          .              ; add 5 to Y
+    ; add 5 to Y
+    tya                                                               ; 41da: 98          .
     clc                                                               ; 41db: 18          .
     adc #5                                                            ; 41dc: 69 05       i.
     tay                                                               ; 41de: a8          .
@@ -11618,7 +11621,8 @@ screen_addr_high = opcode10+2
     bne check_for_collision_horizontal_loop                           ; 4740: d0 f6       ..
     dec sprite_cell_height                                            ; 4742: c6 03       ..
     beq finished_collision_check                                      ; 4744: f0 07       ..
-    tya                                                               ; 4746: 98          .              ; add 37 to Y
+    ; add 37 to Y
+    tya                                                               ; 4746: 98          .
     clc                                                               ; 4747: 18          .
     adc #&25                                                          ; 4748: 69 25       i%
     tay                                                               ; 474a: a8          .
@@ -12186,7 +12190,8 @@ screen_addr_high = opcode10+2
     jmp check_play_sound_a                                            ; 4af0: 4c 65 40    Le@
 
 .check_next_enemy_state
-    tya                                                               ; 4af3: 98          .              ; add 6 to Y
+    ; add 6 to Y
+    tya                                                               ; 4af3: 98          .
     clc                                                               ; 4af4: 18          .
     adc #6                                                            ; 4af5: 69 06       i.
     tay                                                               ; 4af7: a8          .

--- a/examples/known_good/planb_new_label_maker_acme.asm
+++ b/examples/known_good/planb_new_label_maker_acme.asm
@@ -9806,7 +9806,8 @@ decrement_loop_counter
     dec temp_loop_counter                                             ; 3bc8: c6 21       .!
     beq return_1                                                      ; 3bca: f0 07       ..
 next_enemy
-    tya                                                               ; 3bcc: 98          .              ; add 6 to Y
+    ; add 6 to Y
+    tya                                                               ; 3bcc: 98          .
     clc                                                               ; 3bcd: 18          .
     adc #6                                                            ; 3bce: 69 06       i.
     tay                                                               ; 3bd0: a8          .
@@ -10084,7 +10085,8 @@ update_enemies
 update_enemies_loop
     lda enemies_state,y                                               ; 3d95: b9 00 0c    ...
     beq update_enemy                                                  ; 3d98: f0 07       ..
-    tya                                                               ; 3d9a: 98          .              ; add 6 to Y
+    ; add 6 to Y
+    tya                                                               ; 3d9a: 98          .
     clc                                                               ; 3d9b: 18          .
     adc #6                                                            ; 3d9c: 69 06       i.
     tay                                                               ; 3d9e: a8          .
@@ -10702,7 +10704,8 @@ skip_reset_bits
     adc #5                                                            ; 41d4: 69 05       i.
     bit current_room_door_info                                        ; 41d6: 24 15       $.
     bvc got_door_coordinates                                          ; 41d8: 50 07       P.             ; if door is horizontal then branch
-    tya                                                               ; 41da: 98          .              ; add 5 to Y
+    ; add 5 to Y
+    tya                                                               ; 41da: 98          .
     clc                                                               ; 41db: 18          .
     adc #5                                                            ; 41dc: 69 05       i.
     tay                                                               ; 41de: a8          .
@@ -11618,7 +11621,8 @@ check_for_collision_horizontal_loop
     bne check_for_collision_horizontal_loop                           ; 4740: d0 f6       ..
     dec sprite_cell_height                                            ; 4742: c6 03       ..
     beq finished_collision_check                                      ; 4744: f0 07       ..
-    tya                                                               ; 4746: 98          .              ; add 37 to Y
+    ; add 37 to Y
+    tya                                                               ; 4746: 98          .
     clc                                                               ; 4747: 18          .
     adc #$25                                                          ; 4748: 69 25       i%
     tay                                                               ; 474a: a8          .
@@ -12186,7 +12190,8 @@ check_enemies_state_loop
     jmp check_play_sound_a                                            ; 4af0: 4c 65 40    Le@
 
 check_next_enemy_state
-    tya                                                               ; 4af3: 98          .              ; add 6 to Y
+    ; add 6 to Y
+    tya                                                               ; 4af3: 98          .
     clc                                                               ; 4af4: 18          .
     adc #6                                                            ; 4af5: 69 06       i.
     tay                                                               ; 4af7: a8          .

--- a/examples/known_good/planb_new_label_maker_beebasm.asm
+++ b/examples/known_good/planb_new_label_maker_beebasm.asm
@@ -9806,7 +9806,8 @@ osbyte                          = &fff4
     dec temp_loop_counter                                             ; 3bc8: c6 21       .!
     beq return_1                                                      ; 3bca: f0 07       ..
 .next_enemy
-    tya                                                               ; 3bcc: 98          .              ; add 6 to Y
+    ; add 6 to Y
+    tya                                                               ; 3bcc: 98          .
     clc                                                               ; 3bcd: 18          .
     adc #6                                                            ; 3bce: 69 06       i.
     tay                                                               ; 3bd0: a8          .
@@ -10084,7 +10085,8 @@ osbyte                          = &fff4
 .update_enemies_loop
     lda enemies_state,y                                               ; 3d95: b9 00 0c    ...
     beq update_enemy                                                  ; 3d98: f0 07       ..
-    tya                                                               ; 3d9a: 98          .              ; add 6 to Y
+    ; add 6 to Y
+    tya                                                               ; 3d9a: 98          .
     clc                                                               ; 3d9b: 18          .
     adc #6                                                            ; 3d9c: 69 06       i.
     tay                                                               ; 3d9e: a8          .
@@ -10702,7 +10704,8 @@ routine_addr_high = opcode1+2
     adc #5                                                            ; 41d4: 69 05       i.
     bit current_room_door_info                                        ; 41d6: 24 15       $.
     bvc got_door_coordinates                                          ; 41d8: 50 07       P.             ; if door is horizontal then branch
-    tya                                                               ; 41da: 98          .              ; add 5 to Y
+    ; add 5 to Y
+    tya                                                               ; 41da: 98          .
     clc                                                               ; 41db: 18          .
     adc #5                                                            ; 41dc: 69 05       i.
     tay                                                               ; 41de: a8          .
@@ -11618,7 +11621,8 @@ screen_addr_high = opcode10+2
     bne check_for_collision_horizontal_loop                           ; 4740: d0 f6       ..
     dec sprite_cell_height                                            ; 4742: c6 03       ..
     beq finished_collision_check                                      ; 4744: f0 07       ..
-    tya                                                               ; 4746: 98          .              ; add 37 to Y
+    ; add 37 to Y
+    tya                                                               ; 4746: 98          .
     clc                                                               ; 4747: 18          .
     adc #&25                                                          ; 4748: 69 25       i%
     tay                                                               ; 474a: a8          .
@@ -12186,7 +12190,8 @@ screen_addr_high = opcode10+2
     jmp check_play_sound_a                                            ; 4af0: 4c 65 40    Le@
 
 .check_next_enemy_state
-    tya                                                               ; 4af3: 98          .              ; add 6 to Y
+    ; add 6 to Y
+    tya                                                               ; 4af3: 98          .
     clc                                                               ; 4af4: 18          .
     adc #6                                                            ; 4af5: 69 06       i.
     tay                                                               ; 4af7: a8          .

--- a/examples/known_good/planb_new_label_maker_xa.asm
+++ b/examples/known_good/planb_new_label_maker_xa.asm
@@ -9806,7 +9806,8 @@ decrement_loop_counter
     dec temp_loop_counter                                             // 3bc8: c6 21       .!
     beq return_1                                                      // 3bca: f0 07       ..
 next_enemy
-    tya                                                               // 3bcc: 98          .              // add 6 to Y
+    // add 6 to Y
+    tya                                                               // 3bcc: 98          .
     clc                                                               // 3bcd: 18          .
     adc #6                                                            // 3bce: 69 06       i.
     tay                                                               // 3bd0: a8          .
@@ -10085,7 +10086,8 @@ update_enemies
 update_enemies_loop
     lda enemies_state,y                                               // 3d95: b9 00 0c    ...
     beq update_enemy                                                  // 3d98: f0 07       ..
-    tya                                                               // 3d9a: 98          .              // add 6 to Y
+    // add 6 to Y
+    tya                                                               // 3d9a: 98          .
     clc                                                               // 3d9b: 18          .
     adc #6                                                            // 3d9c: 69 06       i.
     tay                                                               // 3d9e: a8          .
@@ -10703,7 +10705,8 @@ skip_reset_bits
     adc #5                                                            // 41d4: 69 05       i.
     bit current_room_door_info                                        // 41d6: 24 15       $.
     bvc got_door_coordinates                                          // 41d8: 50 07       P.             // if door is horizontal then branch
-    tya                                                               // 41da: 98          .              // add 5 to Y
+    // add 5 to Y
+    tya                                                               // 41da: 98          .
     clc                                                               // 41db: 18          .
     adc #5                                                            // 41dc: 69 05       i.
     tay                                                               // 41de: a8          .
@@ -11619,7 +11622,8 @@ check_for_collision_horizontal_loop
     bne check_for_collision_horizontal_loop                           // 4740: d0 f6       ..
     dec sprite_cell_height                                            // 4742: c6 03       ..
     beq finished_collision_check                                      // 4744: f0 07       ..
-    tya                                                               // 4746: 98          .              // add 37 to Y
+    // add 37 to Y
+    tya                                                               // 4746: 98          .
     clc                                                               // 4747: 18          .
     adc #$25                                                          // 4748: 69 25       i%
     tay                                                               // 474a: a8          .
@@ -12187,7 +12191,8 @@ check_enemies_state_loop
     jmp check_play_sound_a                                            // 4af0: 4c 65 40    Le@
 
 check_next_enemy_state
-    tya                                                               // 4af3: 98          .              // add 6 to Y
+    // add 6 to Y
+    tya                                                               // 4af3: 98          .
     clc                                                               // 4af4: 18          .
     adc #6                                                            // 4af5: 69 06       i.
     tay                                                               // 4af7: a8          .

--- a/examples/known_good/planb_xa.asm
+++ b/examples/known_good/planb_xa.asm
@@ -9806,7 +9806,8 @@ decrement_loop_counter
     dec temp_loop_counter                                             // 3bc8: c6 21       .!
     beq return_1                                                      // 3bca: f0 07       ..
 next_enemy
-    tya                                                               // 3bcc: 98          .              // add 6 to Y
+    // add 6 to Y
+    tya                                                               // 3bcc: 98          .
     clc                                                               // 3bcd: 18          .
     adc #6                                                            // 3bce: 69 06       i.
     tay                                                               // 3bd0: a8          .
@@ -10085,7 +10086,8 @@ update_enemies
 update_enemies_loop
     lda enemies_state,y                                               // 3d95: b9 00 0c    ...
     beq update_enemy                                                  // 3d98: f0 07       ..
-    tya                                                               // 3d9a: 98          .              // add 6 to Y
+    // add 6 to Y
+    tya                                                               // 3d9a: 98          .
     clc                                                               // 3d9b: 18          .
     adc #6                                                            // 3d9c: 69 06       i.
     tay                                                               // 3d9e: a8          .
@@ -10703,7 +10705,8 @@ skip_reset_bits
     adc #5                                                            // 41d4: 69 05       i.
     bit current_room_door_info                                        // 41d6: 24 15       $.
     bvc got_door_coordinates                                          // 41d8: 50 07       P.             // if door is horizontal then branch
-    tya                                                               // 41da: 98          .              // add 5 to Y
+    // add 5 to Y
+    tya                                                               // 41da: 98          .
     clc                                                               // 41db: 18          .
     adc #5                                                            // 41dc: 69 05       i.
     tay                                                               // 41de: a8          .
@@ -11619,7 +11622,8 @@ check_for_collision_horizontal_loop
     bne check_for_collision_horizontal_loop                           // 4740: d0 f6       ..
     dec sprite_cell_height                                            // 4742: c6 03       ..
     beq finished_collision_check                                      // 4744: f0 07       ..
-    tya                                                               // 4746: 98          .              // add 37 to Y
+    // add 37 to Y
+    tya                                                               // 4746: 98          .
     clc                                                               // 4747: 18          .
     adc #$25                                                          // 4748: 69 25       i%
     tay                                                               // 474a: a8          .
@@ -12187,7 +12191,8 @@ check_enemies_state_loop
     jmp check_play_sound_a                                            // 4af0: 4c 65 40    Le@
 
 check_next_enemy_state
-    tya                                                               // 4af3: 98          .              // add 6 to Y
+    // add 6 to Y
+    tya                                                               // 4af3: 98          .
     clc                                                               // 4af4: 18          .
     adc #6                                                            // 4af5: 69 06       i.
     tay                                                               // 4af7: a8          .

--- a/examples/known_good/starship_acme.asm
+++ b/examples/known_good/starship_acme.asm
@@ -1249,7 +1249,8 @@ skip_damage
     rts                                                               ; 2704: 60          `   :1604[1]
 
 move_to_next_enemy
-    txa                                                               ; 2705: 8a          .   :1605[1]   ; add 11 to X
+    ; add 11 to X
+    txa                                                               ; 2705: 8a          .   :1605[1]
     clc                                                               ; 2706: 18          .   :1606[1]
     adc #$0b                                                          ; 2707: 69 0b       i.  :1607[1]
     tax                                                               ; 2709: aa          .   :1609[1]
@@ -1370,7 +1371,8 @@ enemy_ship_not_on_starship_screen
     lda #1                                                            ; 27dc: a9 01       ..  :16dc[1]
 set_enemy_ships_on_screen
     sta enemy_ships_on_screen,x                                       ; 27de: 9d 80 04    ... :16de[1]
-    txa                                                               ; 27e1: 8a          .   :16e1[1]   ; add 11 to X
+    ; add 11 to X
+    txa                                                               ; 27e1: 8a          .   :16e1[1]
     clc                                                               ; 27e2: 18          .   :16e2[1]
     adc #$0b                                                          ; 27e3: 69 0b       i.  :16e3[1]
     tax                                                               ; 27e5: aa          .   :16e5[1]
@@ -1453,7 +1455,8 @@ copy_position_without_plotting
     sta enemy_ships_previous_x_screens,x                              ; 2885: 9d 03 04    ... :1785[1]
     lda enemy_ships_x_fraction,x                                      ; 2888: bd 81 04    ... :1788[1]
     sta enemy_ships_previous_x_fraction,x                             ; 288b: 9d 01 04    ... :178b[1]
-    txa                                                               ; 288e: 8a          .   :178e[1]   ; add 11 to X
+    ; add 11 to X
+    txa                                                               ; 288e: 8a          .   :178e[1]
     clc                                                               ; 288f: 18          .   :178f[1]
     adc #$0b                                                          ; 2890: 69 0b       i.  :1790[1]
     tax                                                               ; 2892: aa          .   :1792[1]
@@ -2086,7 +2089,8 @@ activate_shields_when_enemy_ship_enters_main_square
 activate_shields_when_enemy_ship_enters_main_square_loop
     lda enemy_ships_on_screen,x                                       ; 2ca9: bd 80 04    ... :1ba9[1]
     beq enemy_ship_is_on_screen                                       ; 2cac: f0 12       ..  :1bac[1]
-    txa                                                               ; 2cae: 8a          .   :1bae[1]   ; add 11 to X
+    ; add 11 to X
+    txa                                                               ; 2cae: 8a          .   :1bae[1]
     clc                                                               ; 2caf: 18          .   :1baf[1]
     adc #$0b                                                          ; 2cb0: 69 0b       i.  :1bb0[1]
     tax                                                               ; 2cb2: aa          .   :1bb2[1]
@@ -3724,7 +3728,8 @@ enemy_ship_has_sufficient_energy_to_cloak
     ora #4                                                            ; 37ba: 09 04       ..  :26ba[1]
     sta enemy_ships_type,x                                            ; 37bc: 9d 0a 04    ... :26bc[1]
 handle_enemy_ships_cloaking_next
-    txa                                                               ; 37bf: 8a          .   :26bf[1]   ; add 11 to X
+    ; add 11 to X
+    txa                                                               ; 37bf: 8a          .   :26bf[1]
     clc                                                               ; 37c0: 18          .   :26c0[1]
     adc #$0b                                                          ; 37c1: 69 0b       i.  :26c1[1]
     tax                                                               ; 37c3: aa          .   :26c3[1]
@@ -6046,7 +6051,8 @@ initialise_enemy_ships_loop
     jsr initialise_enemy_ship                                         ; 471c: 20 d2 33     .3 :361c[1]
     lda #1                                                            ; 471f: a9 01       ..  :361f[1]
     sta enemy_ships_previous_on_screen,x                              ; 4721: 9d 00 04    ... :3621[1]
-    txa                                                               ; 4724: 8a          .   :3624[1]   ; add 11 to X
+    ; add 11 to X
+    txa                                                               ; 4724: 8a          .   :3624[1]
     clc                                                               ; 4725: 18          .   :3625[1]
     adc #$0b                                                          ; 4726: 69 0b       i.  :3626[1]
     tax                                                               ; 4728: aa          .   :3628[1]
@@ -6177,7 +6183,8 @@ skip_changing_behaviour_type
     and #$f0                                                          ; 481b: 29 f0       ).  :371b[1]
 skip_resetting_hit_count
     sta enemy_ships_temporary_behaviour_flags,x                       ; 481d: 9d 88 04    ... :371d[1]
-    txa                                                               ; 4820: 8a          .   :3720[1]   ; add 11 to X
+    ; add 11 to X
+    txa                                                               ; 4820: 8a          .   :3720[1]
     clc                                                               ; 4821: 18          .   :3721[1]
     adc #$0b                                                          ; 4822: 69 0b       i.  :3722[1]
     tax                                                               ; 4824: aa          .   :3724[1]
@@ -7259,7 +7266,8 @@ consider_records_loop
     cmp high_score_table + 2,x                                        ; 561a: dd 37 43    .7C :451a[1]
     bcs higher_score                                                  ; 561d: b0 0a       ..  :451d[1]
 consider_next_record
-    txa                                                               ; 561f: 8a          .   :451f[1]   ; add 16 to X
+    ; add 16 to X
+    txa                                                               ; 561f: 8a          .   :451f[1]
     clc                                                               ; 5620: 18          .   :4520[1]
     adc #$10                                                          ; 5621: 69 10       i.  :4521[1]
     tax                                                               ; 5623: aa          .   :4523[1]

--- a/examples/known_good/starship_beebasm.asm
+++ b/examples/known_good/starship_beebasm.asm
@@ -1249,7 +1249,8 @@ osbyte                                  = &fff4
     rts                                                               ; 2704: 60          `   :1604[1]
 
 .move_to_next_enemy
-    txa                                                               ; 2705: 8a          .   :1605[1]   ; add 11 to X
+    ; add 11 to X
+    txa                                                               ; 2705: 8a          .   :1605[1]
     clc                                                               ; 2706: 18          .   :1606[1]
     adc #&0b                                                          ; 2707: 69 0b       i.  :1607[1]
     tax                                                               ; 2709: aa          .   :1609[1]
@@ -1370,7 +1371,8 @@ osbyte                                  = &fff4
     lda #1                                                            ; 27dc: a9 01       ..  :16dc[1]
 .set_enemy_ships_on_screen
     sta enemy_ships_on_screen,x                                       ; 27de: 9d 80 04    ... :16de[1]
-    txa                                                               ; 27e1: 8a          .   :16e1[1]   ; add 11 to X
+    ; add 11 to X
+    txa                                                               ; 27e1: 8a          .   :16e1[1]
     clc                                                               ; 27e2: 18          .   :16e2[1]
     adc #&0b                                                          ; 27e3: 69 0b       i.  :16e3[1]
     tax                                                               ; 27e5: aa          .   :16e5[1]
@@ -1453,7 +1455,8 @@ osbyte                                  = &fff4
     sta enemy_ships_previous_x_screens,x                              ; 2885: 9d 03 04    ... :1785[1]
     lda enemy_ships_x_fraction,x                                      ; 2888: bd 81 04    ... :1788[1]
     sta enemy_ships_previous_x_fraction,x                             ; 288b: 9d 01 04    ... :178b[1]
-    txa                                                               ; 288e: 8a          .   :178e[1]   ; add 11 to X
+    ; add 11 to X
+    txa                                                               ; 288e: 8a          .   :178e[1]
     clc                                                               ; 288f: 18          .   :178f[1]
     adc #&0b                                                          ; 2890: 69 0b       i.  :1790[1]
     tax                                                               ; 2892: aa          .   :1792[1]
@@ -2086,7 +2089,8 @@ osbyte                                  = &fff4
 .activate_shields_when_enemy_ship_enters_main_square_loop
     lda enemy_ships_on_screen,x                                       ; 2ca9: bd 80 04    ... :1ba9[1]
     beq enemy_ship_is_on_screen                                       ; 2cac: f0 12       ..  :1bac[1]
-    txa                                                               ; 2cae: 8a          .   :1bae[1]   ; add 11 to X
+    ; add 11 to X
+    txa                                                               ; 2cae: 8a          .   :1bae[1]
     clc                                                               ; 2caf: 18          .   :1baf[1]
     adc #&0b                                                          ; 2cb0: 69 0b       i.  :1bb0[1]
     tax                                                               ; 2cb2: aa          .   :1bb2[1]
@@ -3724,7 +3728,8 @@ osbyte                                  = &fff4
     ora #4                                                            ; 37ba: 09 04       ..  :26ba[1]
     sta enemy_ships_type,x                                            ; 37bc: 9d 0a 04    ... :26bc[1]
 .handle_enemy_ships_cloaking_next
-    txa                                                               ; 37bf: 8a          .   :26bf[1]   ; add 11 to X
+    ; add 11 to X
+    txa                                                               ; 37bf: 8a          .   :26bf[1]
     clc                                                               ; 37c0: 18          .   :26c0[1]
     adc #&0b                                                          ; 37c1: 69 0b       i.  :26c1[1]
     tax                                                               ; 37c3: aa          .   :26c3[1]
@@ -6046,7 +6051,8 @@ osbyte                                  = &fff4
     jsr initialise_enemy_ship                                         ; 471c: 20 d2 33     .3 :361c[1]
     lda #1                                                            ; 471f: a9 01       ..  :361f[1]
     sta enemy_ships_previous_on_screen,x                              ; 4721: 9d 00 04    ... :3621[1]
-    txa                                                               ; 4724: 8a          .   :3624[1]   ; add 11 to X
+    ; add 11 to X
+    txa                                                               ; 4724: 8a          .   :3624[1]
     clc                                                               ; 4725: 18          .   :3625[1]
     adc #&0b                                                          ; 4726: 69 0b       i.  :3626[1]
     tax                                                               ; 4728: aa          .   :3628[1]
@@ -6177,7 +6183,8 @@ osbyte                                  = &fff4
     and #&f0                                                          ; 481b: 29 f0       ).  :371b[1]
 .skip_resetting_hit_count
     sta enemy_ships_temporary_behaviour_flags,x                       ; 481d: 9d 88 04    ... :371d[1]
-    txa                                                               ; 4820: 8a          .   :3720[1]   ; add 11 to X
+    ; add 11 to X
+    txa                                                               ; 4820: 8a          .   :3720[1]
     clc                                                               ; 4821: 18          .   :3721[1]
     adc #&0b                                                          ; 4822: 69 0b       i.  :3722[1]
     tax                                                               ; 4824: aa          .   :3724[1]
@@ -7259,7 +7266,8 @@ osbyte                                  = &fff4
     cmp high_score_table + 2,x                                        ; 561a: dd 37 43    .7C :451a[1]
     bcs higher_score                                                  ; 561d: b0 0a       ..  :451d[1]
 .consider_next_record
-    txa                                                               ; 561f: 8a          .   :451f[1]   ; add 16 to X
+    ; add 16 to X
+    txa                                                               ; 561f: 8a          .   :451f[1]
     clc                                                               ; 5620: 18          .   :4520[1]
     adc #&10                                                          ; 5621: 69 10       i.  :4521[1]
     tax                                                               ; 5623: aa          .   :4523[1]

--- a/examples/known_good/starship_xa.asm
+++ b/examples/known_good/starship_xa.asm
@@ -1249,7 +1249,8 @@ skip_damage
     rts                                                               // 2704: 60          `   :1604[1]
 
 move_to_next_enemy
-    txa                                                               // 2705: 8a          .   :1605[1]   // add 11 to X
+    // add 11 to X
+    txa                                                               // 2705: 8a          .   :1605[1]
     clc                                                               // 2706: 18          .   :1606[1]
     adc #$0b                                                          // 2707: 69 0b       i.  :1607[1]
     tax                                                               // 2709: aa          .   :1609[1]
@@ -1370,7 +1371,8 @@ enemy_ship_not_on_starship_screen
     lda #1                                                            // 27dc: a9 01       ..  :16dc[1]
 set_enemy_ships_on_screen
     sta enemy_ships_on_screen,x                                       // 27de: 9d 80 04    ... :16de[1]
-    txa                                                               // 27e1: 8a          .   :16e1[1]   // add 11 to X
+    // add 11 to X
+    txa                                                               // 27e1: 8a          .   :16e1[1]
     clc                                                               // 27e2: 18          .   :16e2[1]
     adc #$0b                                                          // 27e3: 69 0b       i.  :16e3[1]
     tax                                                               // 27e5: aa          .   :16e5[1]
@@ -1453,7 +1455,8 @@ copy_position_without_plotting
     sta enemy_ships_previous_x_screens,x                              // 2885: 9d 03 04    ... :1785[1]
     lda enemy_ships_x_fraction,x                                      // 2888: bd 81 04    ... :1788[1]
     sta enemy_ships_previous_x_fraction,x                             // 288b: 9d 01 04    ... :178b[1]
-    txa                                                               // 288e: 8a          .   :178e[1]   // add 11 to X
+    // add 11 to X
+    txa                                                               // 288e: 8a          .   :178e[1]
     clc                                                               // 288f: 18          .   :178f[1]
     adc #$0b                                                          // 2890: 69 0b       i.  :1790[1]
     tax                                                               // 2892: aa          .   :1792[1]
@@ -2086,7 +2089,8 @@ activate_shields_when_enemy_ship_enters_main_square
 activate_shields_when_enemy_ship_enters_main_square_loop
     lda enemy_ships_on_screen,x                                       // 2ca9: bd 80 04    ... :1ba9[1]
     beq enemy_ship_is_on_screen                                       // 2cac: f0 12       ..  :1bac[1]
-    txa                                                               // 2cae: 8a          .   :1bae[1]   // add 11 to X
+    // add 11 to X
+    txa                                                               // 2cae: 8a          .   :1bae[1]
     clc                                                               // 2caf: 18          .   :1baf[1]
     adc #$0b                                                          // 2cb0: 69 0b       i.  :1bb0[1]
     tax                                                               // 2cb2: aa          .   :1bb2[1]
@@ -3724,7 +3728,8 @@ enemy_ship_has_sufficient_energy_to_cloak
     ora #4                                                            // 37ba: 09 04       ..  :26ba[1]
     sta enemy_ships_type,x                                            // 37bc: 9d 0a 04    ... :26bc[1]
 handle_enemy_ships_cloaking_next
-    txa                                                               // 37bf: 8a          .   :26bf[1]   // add 11 to X
+    // add 11 to X
+    txa                                                               // 37bf: 8a          .   :26bf[1]
     clc                                                               // 37c0: 18          .   :26c0[1]
     adc #$0b                                                          // 37c1: 69 0b       i.  :26c1[1]
     tax                                                               // 37c3: aa          .   :26c3[1]
@@ -6046,7 +6051,8 @@ initialise_enemy_ships_loop
     jsr initialise_enemy_ship                                         // 471c: 20 d2 33     .3 :361c[1]
     lda #1                                                            // 471f: a9 01       ..  :361f[1]
     sta enemy_ships_previous_on_screen,x                              // 4721: 9d 00 04    ... :3621[1]
-    txa                                                               // 4724: 8a          .   :3624[1]   // add 11 to X
+    // add 11 to X
+    txa                                                               // 4724: 8a          .   :3624[1]
     clc                                                               // 4725: 18          .   :3625[1]
     adc #$0b                                                          // 4726: 69 0b       i.  :3626[1]
     tax                                                               // 4728: aa          .   :3628[1]
@@ -6177,7 +6183,8 @@ skip_changing_behaviour_type
     and #$f0                                                          // 481b: 29 f0       ).  :371b[1]
 skip_resetting_hit_count
     sta enemy_ships_temporary_behaviour_flags,x                       // 481d: 9d 88 04    ... :371d[1]
-    txa                                                               // 4820: 8a          .   :3720[1]   // add 11 to X
+    // add 11 to X
+    txa                                                               // 4820: 8a          .   :3720[1]
     clc                                                               // 4821: 18          .   :3721[1]
     adc #$0b                                                          // 4822: 69 0b       i.  :3722[1]
     tax                                                               // 4824: aa          .   :3724[1]
@@ -7259,7 +7266,8 @@ consider_records_loop
     cmp high_score_table + 2,x                                        // 561a: dd 37 43    .7C :451a[1]
     bcs higher_score                                                  // 561d: b0 0a       ..  :451d[1]
 consider_next_record
-    txa                                                               // 561f: 8a          .   :451f[1]   // add 16 to X
+    // add 16 to X
+    txa                                                               // 561f: 8a          .   :451f[1]
     clc                                                               // 5620: 18          .   :4520[1]
     adc #$10                                                          // 5621: 69 10       i.  :4521[1]
     tax                                                               // 5623: aa          .   :4523[1]

--- a/py8dis/snippets6502.py
+++ b/py8dis/snippets6502.py
@@ -17,10 +17,10 @@ OPCODE_BNE                      = 0xd0      # bne loop
 OPCODE_TXA                      = 0x8a      # txa
 OPCODE_TYA                      = 0x98      # tya
 
-# The list of 'SnippetDetails' which contain a regex for binary data to find common code tropes, 
-# and two associated functions (for commenting, adding expressions etc). 
+# The list of 'SnippetDetails' which contain a regex for binary data to find common code tropes,
+# and two associated functions (for commenting, adding expressions etc).
 # One function is executed before the code is traced, allowing new entry points to be added for the trace.
-# The other happens after tracing which allows for more detailed comments to be added because we know the 
+# The other happens after tracing which allows for more detailed comments to be added because we know the
 # cpu_state of registers.
 snippets = []
 
@@ -30,7 +30,7 @@ def add_entry(p):
 
 def add_code_comment(p, comment):
     p.entry()
-    disassembly.comment_binary(p.get_start_loc(), comment, align=Align.INLINE, auto_generated=True)
+    disassembly.comment_binary(p.get_start_loc(), comment, indent=1, align=Align.AFTER_LABEL, auto_generated=True)
 
 def add_data_comment(p, comment):
     disassembly.comment_binary(p.get_start_loc(), comment, align=Align.INLINE, auto_generated=True)
@@ -246,11 +246,11 @@ def comment_memory_copy_increment(p):
 
 # ************************************************************************************************
 def comment_add_to_y(p):
-    disassembly.comment_binary(p.get_start_loc(), "add {0} to Y".format(p.get_memory("nn")), indent=0, align=Align.INLINE, auto_generated=True)
+    disassembly.comment_binary(p.get_start_loc(), "add {0} to Y".format(p.get_memory("nn")), indent=1, align=Align.AFTER_LABEL, auto_generated=True)
 
 # ************************************************************************************************
 def comment_add_to_x(p):
-    disassembly.comment_binary(p.get_start_loc(), "add {0} to X".format(p.get_memory("nn")), indent=0, align=Align.INLINE, auto_generated=True)
+    disassembly.comment_binary(p.get_start_loc(), "add {0} to X".format(p.get_memory("nn")), indent=1, align=Align.AFTER_LABEL, auto_generated=True)
 
 # ************************************************************************************************
 def comment_set_memory_r_loop(p, reg, other_reg):
@@ -306,7 +306,7 @@ def comment_set_memory_r_loop(p, reg, other_reg):
             bytes_to_set_string = " " + utils.count_with_units(bytes_to_set, "byte", "bytes"+ " of memory")
         else:
             bytes_to_set_string = " {0} bytes of memory".format(reg.upper())
-        
+
         if to_value == 0:
             # "This loop clears 18 bytes of memory at l20e1+Y"
             return "Clear{0}{1}".format(bytes_to_set_string, dest_label)


### PR DESCRIPTION
Make the auto-generated comments such as "add 8 to Y" and "push X,Y to the stack" not inline. Includes updated known-good examples.